### PR TITLE
Core-Imperialis

### DIFF
--- a/1.6/Defs/GW_PatchDefs.xml
+++ b/1.6/Defs/GW_PatchDefs.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ============================================================ -->
+<!-- GW_PatchDefs.xml                                             -->
+<!-- Native GW Defs for GW patches.                               -->
+<!-- GW_GeneSeeding is defined here so cross-references resolve   -->
+<!-- correctly at load time. It is unresearchable by default —    -->
+<!-- patchGWResearch unlocks and repositions it when toggle is on.-->
+<!-- ============================================================ -->
+
+
+<Defs>
+
+  <!-- MPI_PatchDisabled: a dummy ThingDef used as requiredResearchBuilding
+       on research defs when the corresponding patch toggle is off. Since it is
+       never placed in the world, the research is permanently unresearchable.
+       Removed by the relevant patch when the toggle is on. -->
+  <ThingDef>
+    <defName>MPI_ModMissing_AngelsOfDeath</defName>
+    <label>Mod Missing: Grimworld 40,000 - Angels of Death</label>
+    <category>Item</category>
+    <thingClass>ThingWithComps</thingClass>
+  </ThingDef>
+
+  <ThingDef>
+    <defName>MPI_PatchDisabled</defName>
+    <label>Patch Disabled - See Mod Config</label>
+    <category>Item</category>
+    <thingClass>ThingWithComps</thingClass>
+  </ThingDef>
+
+  <!-- GW_GeneSeeding: defined natively so cross-references       -->
+  <!-- resolve at load time. Locked behind MPI_PatchDisabled and  -->
+  <!-- WoodLog bench by default. patchGWResearch removes the lock -->
+  <!-- and moves it to its real position when toggle is on.       -->
+  <ResearchProjectDef MayRequire="Grimworld.Core" ParentName="GW_ImperiumTechBase">
+    <defName>GW_GeneSeeding</defName>
+    <label>gene seeding</label>
+    <description>Master the ancient Imperial science of genetic manipulation — the same arts used to create the Adeptus Astartes themselves. With this knowledge, the most powerful gene-forged technologies of the Imperium become accessible.\n\nThe secrets of gene-seeding are among the most closely guarded in the Imperium, known only to the Adeptus Mechanicus and the highest ranks of the Astartes Chapters.</description>
+    <techLevel>Spacer</techLevel>
+    <baseCost>2500</baseCost>
+    <researchViewX>14.00</researchViewX>
+    <researchViewY>5.60</researchViewY>
+    <requiredResearchBuilding>MPI_PatchDisabled</requiredResearchBuilding>
+    <prerequisites>
+      <li MayRequire="Ludeon.RimWorld.Biotech">Xenogermination</li>
+      <li>Electricity</li>
+    </prerequisites>
+  </ResearchProjectDef>
+
+  <!-- MPI_GW_Lasguns: new research unlocking additional lasgun variants from
+       Hammer of the Imperium and other GW mods as they are researched.
+       Positioned below Melta Weapons in the research tree. -->
+  <ResearchProjectDef MayRequire="Grimworld.Core" ParentName="GW_ImperiumTechBase">
+    <defName>MPI_GW_Lasguns</defName>
+    <label>lasguns</label>
+    <description>The lasgun is the most common weapon in the Imperium of Man — cheap, reliable, and produced in such staggering numbers that entire armies can be armed with them. It is said that the Emperor's armies march on lasbolts — and the forge worlds of the Imperium have never stopped producing them.</description>
+    <techLevel>Industrial</techLevel>
+    <baseCost>3000</baseCost>
+    <prerequisites>
+      <li>Gunsmithing</li>
+      <li MayRequire="Grimworld.AstraMilitarum">GW_AM_TacticaImperium</li>
+    </prerequisites>
+    <researchViewX>10.00</researchViewX>
+    <researchViewY>5.60</researchViewY>
+    <requiredResearchBuilding>MPI_PatchDisabled</requiredResearchBuilding>
+    <modExtensions>
+      <li Class="GW_Frame.DefModExtension_ExtraPrerequisiteActions">
+        <StudyLocation>GW_Cogitator</StudyLocation>
+        <ItemStudyRequirements>
+          <li Class="GW_Frame.StudyRequirement">
+            <StudyObject>GW_STC_Fragment</StudyObject>
+            <NumberRequired>1</NumberRequired>
+          </li>
+        </ItemStudyRequirements>
+      </li>
+    </modExtensions>
+  </ResearchProjectDef>
+
+  <!-- MPI_GW_ForceWeaponry: new research unlocking Force Weapons for sanctioned
+       psykers and Librarians. Positioned below Plasma Reactor. -->
+  <ResearchProjectDef MayRequire="Grimworld.Core" ParentName="GW_ImperiumTechBase">
+    <defName>MPI_GW_ForceWeaponry</defName>
+    <label>force weaponry artificia</label>
+    <description>Unlock the secrets of Force Weapons — psi-enhanced, power-activated weapons forged at the intersection of technology and psychic science. Commonly wielded by sanctioned psykers and Space Marine Librarians, these weapons channel their bearer's psychic might into devastating strikes. Each blade is as much a psychic focus as it is a weapon, and their construction demands both the finest artificers and the blessing of a sanctioned psyker.</description>
+    <techLevel>Spacer</techLevel>
+    <baseCost>3000</baseCost>
+    <prerequisites>
+      <li>GW_PowerMeleeWeapons</li>
+      <li>GW_Cogitator</li>
+    </prerequisites>
+    <researchViewX>12.00</researchViewX>
+    <researchViewY>5.50</researchViewY>
+    <requiredResearchBuilding>MPI_PatchDisabled</requiredResearchBuilding>
+    <modExtensions>
+      <li Class="GW_Frame.DefModExtension_ExtraPrerequisiteActions">
+        <StudyLocation>GW_Cogitator</StudyLocation>
+        <ItemStudyRequirements>
+          <li Class="GW_Frame.StudyRequirement">
+            <StudyObject>GW_STC_Fragment</StudyObject>
+            <NumberRequired>1</NumberRequired>
+          </li>
+        </ItemStudyRequirements>
+      </li>
+    </modExtensions>
+  </ResearchProjectDef>
+
+  <!-- MPI_GW_AdvancedLasguns: new research unlocking advanced lasgun variants.
+       Positioned below Armageddon Steel Legion in the research tree. -->
+  <ResearchProjectDef MayRequire="Grimworld.Core" ParentName="GW_ImperiumTechBase">
+    <defName>MPI_GW_AdvancedLasguns</defName>
+    <label>advanced lasguns</label>
+    <description>The lasgun may be the backbone of the Imperial Guard, but the Adeptus Mechanicus never stopped refining it. Hellguns, hotshot lasguns, and the esoteric long-las represent the bleeding edge of laser weapons technology — weapons that demand more from their wielder, but reward that mastery with far greater lethality.</description>
+    <techLevel>Spacer</techLevel>
+    <baseCost>7000</baseCost>
+    <prerequisites>
+      <li>MPI_GW_Lasguns</li>
+      <li MayRequire="Grimworld.AstraMilitarum">GW_AM_RegimentsOfRenown</li>
+    </prerequisites>
+    <researchViewX>11.00</researchViewX>
+    <researchViewY>5.60</researchViewY>
+    <requiredResearchBuilding>MPI_PatchDisabled</requiredResearchBuilding>
+    <modExtensions>
+      <li Class="GW_Frame.DefModExtension_ExtraPrerequisiteActions">
+        <StudyLocation>GW_Cogitator</StudyLocation>
+        <ItemStudyRequirements>
+          <li Class="GW_Frame.StudyRequirement">
+            <StudyObject>GW_STC_Fragment</StudyObject>
+            <NumberRequired>2</NumberRequired>
+          </li>
+        </ItemStudyRequirements>
+      </li>
+    </modExtensions>
+  </ResearchProjectDef>
+
+  <!-- MPI_GW_AerythmeticaDiscontinuity: new research unlocking Archaeotech
+       weapons of the Dark Mechanicum. Requires Force Weaponry Artificia. -->
+  <ResearchProjectDef MayRequire="Grimworld.Core" ParentName="GW_ImperiumTechBase">
+    <defName>MPI_GW_AerythmeticaDiscontinuity</defName>
+    <label>Aerythmetica Discontinuity</label>
+    <description>Uncover forbidden principles of the Dark Mechanicum to produce terrifying Archaeotech weaponry. By generating entropic fields that sever nuclear bonds, these arms do not merely wound; they unravel the target's atomic structure, reducing ceramite, flesh, and soul alike.</description>
+    <techLevel>Spacer</techLevel>
+    <baseCost>8000</baseCost>
+    <prerequisites>
+      <li>MPI_GW_ForceWeaponry</li>
+    </prerequisites>
+    <researchViewX>13.00</researchViewX>
+    <researchViewY>5.50</researchViewY>
+    <requiredResearchBuilding>MPI_PatchDisabled</requiredResearchBuilding>
+    <modExtensions>
+      <li Class="GW_Frame.DefModExtension_ExtraPrerequisiteActions">
+        <StudyLocation>GW_Cogitator</StudyLocation>
+        <ItemStudyRequirements>
+          <li Class="GW_Frame.StudyRequirement">
+            <StudyObject>GW_STC_Fragment</StudyObject>
+            <NumberRequired>3</NumberRequired>
+          </li>
+        </ItemStudyRequirements>
+      </li>
+    </modExtensions>
+  </ResearchProjectDef>
+
+</Defs>

--- a/1.6/Defs/SoundDefs.xml
+++ b/1.6/Defs/SoundDefs.xml
@@ -101,4 +101,75 @@
       </li>
     </subSounds>
 	</SoundDef>
+
+	<!-- Grenade launcher launch sound — referenced by Dead Men and other GW mods -->
+	<SoundDef>
+		<defName>GW_Grenade_Gun_Sound</defName>
+		<context>MapOnly</context>
+		<eventNames />
+		<maxSimultaneous>10</maxSimultaneous>
+		<subSounds>
+			<li>
+				<grains>
+					<li Class="AudioGrain_Folder">
+						<clipFolderPath>Weapons/GrenadeLauncher</clipFolderPath>
+					</li>
+				</grains>
+				<volumeRange>35~35</volumeRange>
+			</li>
+		</subSounds>
+	</SoundDef>
+
+	<!-- Moved from Angels-of-Death — referenced by melee weapons in multiple GW mods -->
+	<SoundDef>
+		<defName>Smite</defName>
+		<context>MapOnly</context>
+		<eventNames />
+		<maxSimultaneous>10</maxSimultaneous>
+		<subSounds>
+			<li>
+				<grains>
+					<li Class="AudioGrain_Clip">
+						<clipPath>SmiteSFX</clipPath>
+					</li>
+				</grains>
+				<volumeRange>25~30</volumeRange>
+			</li>
+		</subSounds>
+	</SoundDef>
+
+	<SoundDef>
+		<defName>ChainSword</defName>
+		<context>MapOnly</context>
+		<eventNames />
+		<maxSimultaneous>10</maxSimultaneous>
+		<subSounds>
+			<li>
+				<grains>
+					<li Class="AudioGrain_Folder">
+						<clipFolderPath>Weapons/ChainSword</clipFolderPath>
+					</li>
+				</grains>
+				<volumeRange>35~35</volumeRange>
+			</li>
+		</subSounds>
+	</SoundDef>
+
+	<SoundDef>
+		<defName>PowerSword</defName>
+		<context>MapOnly</context>
+		<eventNames />
+		<maxSimultaneous>10</maxSimultaneous>
+		<subSounds>
+			<li>
+				<grains>
+					<li Class="AudioGrain_Folder">
+						<clipFolderPath>Weapons/PowerSword</clipFolderPath>
+					</li>
+				</grains>
+				<volumeRange>35~35</volumeRange>
+			</li>
+		</subSounds>
+	</SoundDef>
+
 </Defs>

--- a/1.6/Defs/ThingDefs/ThingDefsCorpseStarch.xml
+++ b/1.6/Defs/ThingDefs/ThingDefsCorpseStarch.xml
@@ -41,7 +41,7 @@
       <ingestEffect>EatVegetarian</ingestEffect>
       <ingestSound>Meal_Eat</ingestSound>
       <optimalityOffsetHumanlikes>6</optimalityOffsetHumanlikes>
-	  <specialThoughtDirect>AteHumanlikeMeatDirect</specialThoughtDirect>
+	  <specialThoughtDirect>AteHumanlikeMeatDirectCannibal</specialThoughtDirect> <!-- FIXED: AteHumanlikeMeatDirect applies regardless of ideo -->
     </ingestible>
     <comps>
       <li Class="CompProperties_Rottable">

--- a/1.6/Defs/ThingDefs/ThingDefsResource_Items_Resource_Stuff.xml
+++ b/1.6/Defs/ThingDefs/ThingDefsResource_Items_Resource_Stuff.xml
@@ -53,6 +53,7 @@
                 <DoorOpenSpeed>0.8</DoorOpenSpeed>
                 <MeleeWeapon_CooldownMultiplier>0.5</MeleeWeapon_CooldownMultiplier>
             </statFactors>
+			<isAirtight>true</isAirtight> <!-- PATCHED -->
         </stuffProps>
     </ThingDef>
 
@@ -111,6 +112,7 @@
                 <DoorOpenSpeed>1.7</DoorOpenSpeed>
                 <MeleeWeapon_CooldownMultiplier>0.9</MeleeWeapon_CooldownMultiplier>
             </statFactors>
+			<isAirtight>true</isAirtight> <!-- PATCHED -->
         </stuffProps>
     </ThingDef>
 
@@ -168,6 +170,7 @@
                 <DoorOpenSpeed>2</DoorOpenSpeed>
                 <MeleeWeapon_CooldownMultiplier>1.1</MeleeWeapon_CooldownMultiplier>
             </statFactors>
+			<isAirtight>true</isAirtight> <!-- PATCHED -->
         </stuffProps>
     </ThingDef>
 

--- a/1.6/Defs/ThingDefs/ThingDefs_Structures.xml
+++ b/1.6/Defs/ThingDefs/ThingDefs_Structures.xml
@@ -17,7 +17,7 @@
             </damageData>
         </graphicData>
 		<building>
-			<isAirtight>true</isAirtight>
+			<isStuffableAirtight>true</isStuffableAirtight> <!-- Only metallic doors airtight -->
 		</building>
     </ThingDef>
 
@@ -40,6 +40,9 @@
             <Steel>40</Steel>
             <ComponentIndustrial>2</ComponentIndustrial>
         </costList>
+		<building>
+			<isStuffableAirtight>true</isStuffableAirtight> <!-- Only metallic doors airtight -->
+		</building>
     </ThingDef>
 
     <ThingDef ParentName="GW_DoorBase" Name="GW_BlastDoorBase" Abstract="True">
@@ -67,6 +70,9 @@
             <Steel>100</Steel>
             <ComponentIndustrial>5</ComponentIndustrial>
         </costList>
+		<building>
+			<isAirtight>true</isAirtight> <!-- door can only be metallic so airtight by default -->
+		</building>
     </ThingDef>
 
         <!--The doors-->
@@ -135,7 +141,7 @@
 		<fillPercent>1</fillPercent>		
 		<building>
 			<supportsWallAttachments>true</supportsWallAttachments>
-			<isAirtight>true</isAirtight>
+			<isStuffableAirtight>true</isStuffableAirtight> <!-- Only metallic walls airtight -->
 		</building>
     </ThingDef>
 
@@ -159,7 +165,7 @@
 		<fillPercent>1</fillPercent>		
 		<building>
 			<supportsWallAttachments>true</supportsWallAttachments>
-			<isAirtight>true</isAirtight>
+			<isStuffableAirtight>true</isStuffableAirtight> <!-- Only metallic walls airtight -->
 		</building>
     </ThingDef>
 	
@@ -238,6 +244,7 @@
 				<texPath>Things/Building/Linked/Embrasure/GW_OrdinaryWalls_Emb_Atlas</texPath>
 			</blueprintGraphicData>
 			<paintable MayRequire="Rimworld.Biotech">true</paintable>
+			<isAirtight>false</isAirtight> <!-- never airtight -->
 		</building>
 		<comps>
 		</comps>
@@ -319,6 +326,7 @@
 				<texPath>Things/Building/Linked/Embrasure/GW_ReinforcedWall_Emb_Atlas</texPath>
 			</blueprintGraphicData>
 			<paintable MayRequire="Rimworld.Biotech">true</paintable>
+			<isAirtight>false</isAirtight> <!-- never airtight -->
 		</building>
 		<comps>
 		</comps>

--- a/1.6/Mods/Vehicles/Defs/ThingDefs/Buildings_GarageStructure.xml
+++ b/1.6/Mods/Vehicles/Defs/ThingDefs/Buildings_GarageStructure.xml
@@ -25,7 +25,7 @@
 		<drawerType>RealtimeOnly</drawerType>
 		<building>
 			<isInert>true</isInert>
-			<isAirtight>True</isAirtight>
+			<isStuffableAirtight>true</isStuffableAirtight> <!-- Fixed capitilazition / when metallic = airtight, should be inherited -->
 			<canPlaceOverWall>true</canPlaceOverWall>
 			<soundDoorOpenPowered>Door_OpenPowered</soundDoorOpenPowered>
 			<soundDoorClosePowered>Door_ClosePowered</soundDoorClosePowered>
@@ -82,6 +82,7 @@
 		<designationCategory IsNull="True"/>
 		<building>
 			<isAirtight>false</isAirtight>
+			<isStuffableAirtight>false</isStuffableAirtight> <!-- added in case needed -->
 		</building>
 	</ThingDef>
 
@@ -122,6 +123,7 @@
 		<designationCategory IsNull="True"/>
 		<building>
 			<isAirtight>false</isAirtight>
+			<isStuffableAirtight>false</isStuffableAirtight> <!-- added in case needed -->
 		</building>
 	</ThingDef>
 
@@ -162,6 +164,7 @@
 		<designationCategory IsNull="True"/>
 		<building>
 			<isAirtight>false</isAirtight>
+			<isStuffableAirtight>false</isStuffableAirtight> <!-- added in case needed -->
 		</building>
 	</ThingDef>
 
@@ -214,6 +217,7 @@
 		<designationCategory IsNull="True"/>
 		<building>
 			<isAirtight>false</isAirtight>
+			<isStuffableAirtight>false</isStuffableAirtight> <!-- added in case needed -->
 		</building>
 	</ThingDef>
 
@@ -266,6 +270,7 @@
 		<designationCategory IsNull="True"/>
 		<building>
 			<isAirtight>false</isAirtight>
+			<isStuffableAirtight>false</isStuffableAirtight> <!-- added in case needed -->
 		</building>
 	</ThingDef>
 
@@ -318,6 +323,7 @@
 		<designationCategory IsNull="True"/>
 		<building>
 			<isAirtight>false</isAirtight>
+			<isStuffableAirtight>false</isStuffableAirtight> <!-- added in case needed -->
 		</building>
 	</ThingDef>
 </Defs>

--- a/1.6/Patches/patchGWBalance.xml
+++ b/1.6/Patches/patchGWBalance.xml
@@ -1,0 +1,1874 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ============================================================ -->
+<!-- patchGWBalance.xml                                           -->
+<!-- GW Balance Patch.                                            -->
+<!-- Gates weapons and buildings behind appropriate research.     -->
+<!-- Also handles label fixes and misc balance changes.           -->
+<!-- ============================================================ -->
+<Patch>
+
+  <Operation Class="GW_Frame.PatchOperation_GWPatch">
+    <patchName>GWBalance</patchName>
+    <operations>
+	
+	<!-- ============== MPI Categories =================== -->
+    <!-- MPI_GW_Lasguns — unlock and reposition  --> 
+	  <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="MPI_GW_Lasguns"]/researchViewX</xpath>
+        <value><researchViewX>3.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="MPI_GW_Lasguns"]/researchViewY</xpath>
+        <value><researchViewY>5.00</researchViewY></value>
+      </li>
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="MPI_GW_Lasguns"]/requiredResearchBuilding</xpath>
+      </li>
+    <!-- MPI_GW_AdvancedLasguns — unlock and reposition  --> 
+	  <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="MPI_GW_AdvancedLasguns"]/researchViewX</xpath>
+        <value><researchViewX>4.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="MPI_GW_AdvancedLasguns"]/researchViewY</xpath>
+        <value><researchViewY>5.00</researchViewY></value>
+      </li>
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="MPI_GW_AdvancedLasguns"]/requiredResearchBuilding</xpath>
+      </li>
+    <!-- MPI_GW_ForceWeaponry — unlock and reposition  --> 
+	  <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="MPI_GW_ForceWeaponry"]/researchViewX</xpath>
+        <value><researchViewX>8.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="MPI_GW_ForceWeaponry"]/requiredResearchBuilding</xpath>
+      </li>
+    <!-- MPI_GW_AerythmeticaDiscontinuity — unlock and reposition  --> 
+	  <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="MPI_GW_AerythmeticaDiscontinuity"]/researchViewX</xpath>
+        <value><researchViewX>12.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="MPI_GW_AerythmeticaDiscontinuity"]/requiredResearchBuilding</xpath>
+      </li>
+
+      <!-- MOVED TO patchGene.xml GW_AM_TacticaImperium — add GeneSeeding prereq, remove Electronics 
+      
+	  <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_TacticaImperium"]/prerequisites</xpath>
+        <value><li MayRequire="Grimworld.Core">GW_GeneSeeding</li></value>
+      </li>
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_TacticaImperium"]/prerequisites/li[.="Electricity"]</xpath>
+      </li>	   -->
+	  
+
+
+
+      <!-- ==================== Core Imperialis ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Core Imperialis</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- Walls + Doors → require Imperial Infrastructure research -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_Wall"]</xpath>
+              <value><researchPrerequisites><li>GW_AM_BasicImperiumDefense</li></researchPrerequisites></value>
+            </li>
+            <!-- GW_ReinforcedWall → Imperial Fortifications -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_ReinforcedWall"]</xpath>
+              <value><researchPrerequisites><li>GW_AM_ImperiumDefense</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_EmbrasureArmored"]/researchPrerequisites</xpath>
+              <value><researchPrerequisites><li>GW_AM_ImperiumDefense</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_ImperialisDoor"]</xpath>
+              <value><researchPrerequisites><li>GW_AM_BasicImperiumDefense</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_MechanicusDoor"]</xpath>
+              <value><researchPrerequisites><li>GW_AM_BasicImperiumDefense</li></researchPrerequisites></value>
+            </li>
+
+            <!-- GW_VehicleToolCabinet → require ComplexFurniture research -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_VehicleToolCabinet"]</xpath>
+              <value><researchPrerequisites><li>ComplexFurniture</li></researchPrerequisites></value>
+            </li>
+
+            <!-- Barbed wire + tank traps → Smithing -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="DefensiveBarbedWire"]</xpath>
+              <value><researchPrerequisites><li>Smithing</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="DefensiveTankTrapA"]</xpath>
+              <value><researchPrerequisites><li>Smithing</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="DefensiveTankTrapB"]</xpath>
+              <value><researchPrerequisites><li>Smithing</li></researchPrerequisites></value>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Aspectus Imperialis ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Aspectus Imperialis</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- Candelabra + CandleStand → require Smithing research -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_Candelabra"]</xpath>
+              <value><researchPrerequisites><li>Smithing</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_CandleStand"]</xpath>
+              <value><researchPrerequisites><li>Smithing</li></researchPrerequisites></value>
+            </li>
+			
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Hammer of the Imperium ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Hammer of the Imperium</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- ===== Codex Astartes ===== -->
+            <!-- GW_SM_CodexAstartes → require MicroelectronicsBasics instead of AdvancedFabrication -->
+            <!-- Note: prereq change is handled in patchGWResearch.xml -->
+
+            <!-- Astartes bolter turret → require AdvancedBolters + GunTurrets -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_Building_HeavyBolter"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li>GW_AdvancedBolters</li>
+                  <li>GunTurrets</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+            <!-- Astartes lascannon turret → require AdvancedLasguns + GunTurrets -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_Building_Lascannon"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li>MPI_GW_AdvancedLasguns</li>
+                  <li>GunTurrets</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+
+            <!-- ===== Astartes Fabrication ===== -->
+            <!-- Note: prereq change (require AdvancedFabrication) handled in patchGWResearch.xml -->
+            <!-- Scout armor, helmets, shoulder pads, Fibrovest → handled in Angels of Death section below -->
+
+            <!-- ===== Imperial Fortifications (GW_AM_ImperiumDefense) ===== -->
+            <!-- Heavy bolter turret → GunTurrets + GW_Bolters -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Building_HeavyBolter"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li>GunTurrets</li>
+                  <li>GW_Bolters</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+            <!-- Mannable autocannon turret → GW_Autoguns + HeavyTurrets -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Building_Autocannon"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li>GW_Autoguns</li>
+                  <li>HeavyTurrets</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+            <!-- Mannable lascannon turret → GunTurrets + MPI_GW_Lasguns -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Building_Lascannon"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li>GunTurrets</li>
+                  <li>MPI_GW_Lasguns</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+            <!-- Tarantula heavy bolter → GunTurrets + MicroelectronicsBasics + GW_Bolters -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Building_TarantulaHeavyBolter"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li>GunTurrets</li>
+                  <li>MicroelectronicsBasics</li>
+                  <li>GW_Bolters</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+            <!-- Tarantula lascannon → GunTurrets + MicroelectronicsBasics + MPI_GW_Lasguns -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Building_TarantulaLascannon"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li>GunTurrets</li>
+                  <li>MicroelectronicsBasics</li>
+                  <li>MPI_GW_Lasguns</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+            <!-- Earthshaker cannon → add PrecisionRifling -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Turret_Earthshaker"]</xpath>
+              <value><researchPrerequisites><li>PrecisionRifling</li></researchPrerequisites></value>
+            </li>
+            <!-- 132mm shells → Mortars -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_132mm_HighExplosive"]</xpath>
+              <value><researchPrerequisites><li>Mortars</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_132mm_Smoke"]</xpath>
+              <value><researchPrerequisites><li>Mortars</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_132mm_Incendiary"]</xpath>
+              <value><researchPrerequisites><li>Mortars</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_132mm_AP"]</xpath>
+              <value><researchPrerequisites><li>Mortars</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Officers of Astra Militarum ===== -->
+            <!-- Cadian officer armor sharp armor buff -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_CadianOfficerArmor"]/statBases/ArmorRating_Sharp</xpath>
+              <value><ArmorRating_Sharp>0.865</ArmorRating_Sharp></value>
+            </li>
+            <!-- Cadian flamer webbing → also require GW_Flamers -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_CadianFlamerWebbing"]</xpath>
+              <value><researchPrerequisites><li>GW_Flamers</li></researchPrerequisites></value>
+            </li>
+            <!-- Inferno pistol → also require GW_MeltaWeapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_InfernoPistol"]</xpath>
+              <value><researchPrerequisites><li>GW_MeltaWeapons</li></researchPrerequisites></value>
+            </li>
+            <!-- Plasma pistol → also require GW_PlasmaWeapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_PlasmaPistol"]</xpath>
+              <value><researchPrerequisites><li>GW_PlasmaWeapons</li></researchPrerequisites></value>
+            </li>
+            <!-- Eviscerator + Omni Axe → also require GW_PowerMeleeWeapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Melee_Eviscerator"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Melee_OmniAxe"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+            <!-- Force Staff → require MPI_GW_ForceWeaponry (replaces OfficersOfAM gate) -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Melee_PsykerForceStaff"]/recipeMaker/researchPrerequisite</xpath>
+              <value><researchPrerequisite>MPI_GW_ForceWeaponry</researchPrerequisite></value>
+            </li>
+            <!-- Sanctioned Psyker jacket + helmet → move to MPI_GW_ForceWeaponry -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_CadianPsykerJacket"]/recipeMaker/researchPrerequisite</xpath>
+              <value><researchPrerequisite>MPI_GW_ForceWeaponry</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_CadianPsyker_Helmet"]/recipeMaker/researchPrerequisite</xpath>
+              <value><researchPrerequisite>MPI_GW_ForceWeaponry</researchPrerequisite></value>
+            </li>
+
+            <!-- ===== Base HoI weapons — no existing prereq → Add ===== -->
+            <!-- Bolters -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Gun_BoltPistol"]</xpath>
+              <value><researchPrerequisites><li>GW_Bolters</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Gun_Bolter"]</xpath>
+              <value><researchPrerequisites><li>GW_Bolters</li></researchPrerequisites></value>
+            </li>
+            <!-- Autoguns -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Gun_Agripinaamkii"]</xpath>
+              <value><researchPrerequisites><li>GW_Autoguns</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Gun_Agripinaamkiitanker"]</xpath>
+              <value><researchPrerequisites><li>GW_Autoguns</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Shotgun"]</xpath>
+              <value><researchPrerequisites><li>GW_Autoguns</li></researchPrerequisites></value>
+            </li>
+            <!-- Lasguns (adds MPI_GW_Lasguns alongside existing prereqs) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Gun_Kantrael"]/recipeMaker</xpath>
+              <value><researchPrerequisite>MPI_GW_Lasguns</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Gun_Kantraeldefender"]/recipeMaker</xpath>
+              <value><researchPrerequisite>MPI_GW_Lasguns</researchPrerequisite></value>
+            </li>
+
+            <!-- ===== Catachan Jungle Fighters ===== -->
+            <!-- MK4 lascarbine + sanctified variant → add MPI_GW_Lasguns -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Gun_Lascarbinefour"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_Lasguns</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Gun_Lascarbinefoursanctified"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_Lasguns</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Officers of Astra Militarum ===== -->
+            <!-- Cadian commissar breastplate → ReconArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_CommissarMiddle"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <!-- Death Korps commissar helmet → FlakArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_DM_KriegCommissarHelmet"]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Lucifer Blacks ===== -->
+            <!-- Guns are RoR items — handled in RoR block below -->
+
+            <!-- Power Sword + Power Fist Munitorum patterns → add GW_PowerMeleeWeapons (GW_HOI_ = HoI items) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Melee_PowerSword"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Melee_PowerFist"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Tempestus Scions ===== -->
+            <!-- Hellgun Cadian pattern → MPI_GW_AdvancedLasguns (HoI item) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_TempestusScion_Hellgun"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AdvancedLasguns</li></researchPrerequisites></value>
+            </li>
+            <!-- Scion carapace is RoR — handled in RoR block below -->
+
+    <!-- ===== Militarum Armor — Flak Armor gate ===== -->
+            <!-- Replace recipeMaker prereq → MilitariumArmor (crafting category) -->
+            <!-- Add recipeMaker researchPrerequisites → FlakArmor ("Unlocked with" display) -->
+            <!-- Also patch RecipeDefs directly (more reliable than ThingDef/recipeMaker) -->
+            <!-- Cadian flak + helmets -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_FlakArmor"]/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_FlakArmor"][not(researchPrerequisite)]</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_FlakArmor"][not(researchPrerequisites)]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_FlakArmor"]/researchPrerequisites</xpath>
+              <value><li>FlakArmor</li></value>
+            </li>
+
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CrewArmor"]/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CrewArmor"][not(researchPrerequisite)]</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CrewArmor"][not(researchPrerequisites)]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CrewArmor"]/researchPrerequisites</xpath>
+              <value><li>FlakArmor</li></value>
+            </li>
+
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_Helmet"]/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_Helmet"][not(researchPrerequisite)]</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_Helmet"][not(researchPrerequisites)]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_Helmet"]/researchPrerequisites</xpath>
+              <value><li>FlakArmor</li></value>
+            </li>
+
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CrewHelmet"]/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CrewHelmet"][not(researchPrerequisite)]</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CrewHelmet"][not(researchPrerequisites)]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CrewHelmet"]/researchPrerequisites</xpath>
+              <value><li>FlakArmor</li></value>
+            </li>
+
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CrewHelmetSoft"]/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CrewHelmetSoft"][not(researchPrerequisite)]</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CrewHelmetSoft"][not(researchPrerequisites)]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CrewHelmetSoft"]/researchPrerequisites</xpath>
+              <value><li>FlakArmor</li></value>
+            </li>
+
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_WhiteShieldHelmet"]/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_WhiteShieldHelmet"][not(researchPrerequisite)]</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_WhiteShieldHelmet"][not(researchPrerequisites)]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_WhiteShieldHelmet"]/researchPrerequisites</xpath>
+              <value><li>FlakArmor</li></value>
+            </li>
+
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_FlakArmor"]/recipeMaker/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_FlakArmor"]/recipeMaker[not(researchPrerequisite)]</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_FlakArmor"]/recipeMaker[not(researchPrerequisites)]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_FlakArmor"]/recipeMaker/researchPrerequisites</xpath>
+              <value><li>FlakArmor</li></value>
+            </li>
+
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewArmor"]/recipeMaker/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewArmor"]/recipeMaker[not(researchPrerequisite)]</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewArmor"]/recipeMaker[not(researchPrerequisites)]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewArmor"]/recipeMaker/researchPrerequisites</xpath>
+              <value><li>FlakArmor</li></value>
+            </li>
+
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_Helmet"]/recipeMaker/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_Helmet"]/recipeMaker[not(researchPrerequisite)]</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_Helmet"]/recipeMaker[not(researchPrerequisites)]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_Helmet"]/recipeMaker/researchPrerequisites</xpath>
+              <value><li>FlakArmor</li></value>
+            </li>
+
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewHelmet"]/recipeMaker/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewHelmet"]/recipeMaker[not(researchPrerequisite)]</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewHelmet"]/recipeMaker[not(researchPrerequisites)]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewHelmet"]/recipeMaker/researchPrerequisites</xpath>
+              <value><li>FlakArmor</li></value>
+            </li>
+
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewHelmetSoft"]/recipeMaker/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewHelmetSoft"]/recipeMaker[not(researchPrerequisite)]</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewHelmetSoft"]/recipeMaker[not(researchPrerequisites)]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewHelmetSoft"]/recipeMaker/researchPrerequisites</xpath>
+              <value><li>FlakArmor</li></value>
+            </li>
+
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_WhiteShieldHelmet"]/recipeMaker/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_WhiteShieldHelmet"]/recipeMaker[not(researchPrerequisite)]</xpath>
+              <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_WhiteShieldHelmet"]/recipeMaker[not(researchPrerequisites)]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_WhiteShieldHelmet"]/recipeMaker/researchPrerequisites</xpath>
+              <value><li>FlakArmor</li></value>
+            </li>
+
+            <!-- ===== Castellan armor + helmet — also require GW_TotE_Castellan if TotE loaded ===== -->
+            <li Class="PatchOperationFindMod" MayFail="true">
+              <mods><li>GrimWorld 40,000 - Talons of the Emperor</li></mods>
+              <match Class="PatchOperationSequence">
+                <operations>
+                  <!-- Castellan gear RecipeDefs (primary category + secondary unlock gates) -->
+                  <li Class="PatchOperationReplace" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_CadianCommanderArmor"]/researchPrerequisite</xpath>
+                    <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_CadianCommanderArmor"][not(researchPrerequisite)]</xpath>
+                    <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_CadianCommanderArmor"][not(researchPrerequisites)]</xpath>
+                    <value>
+                      <researchPrerequisites>
+                        <li>GW_TotE_Castellan</li>
+                        <li>FlakArmor</li>
+                      </researchPrerequisites>
+                    </value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_CadianCommanderArmor"]/researchPrerequisites</xpath>
+                    <value><li>GW_TotE_Castellan</li></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_CadianCommanderArmor"]/researchPrerequisites</xpath>
+                    <value><li>FlakArmor</li></value>
+                  </li>
+
+                  <!-- Helmet: hedge both spellings -->
+                  <li Class="PatchOperationReplace" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CastellenHelmet"]/researchPrerequisite</xpath>
+                    <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CastellenHelmet"][not(researchPrerequisite)]</xpath>
+                    <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CastellenHelmet"][not(researchPrerequisites)]</xpath>
+                    <value>
+                      <researchPrerequisites>
+                        <li>GW_TotE_Castellan</li>
+                        <li>FlakArmor</li>
+                      </researchPrerequisites>
+                    </value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CastellenHelmet"]/researchPrerequisites</xpath>
+                    <value><li>GW_TotE_Castellan</li></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CastellenHelmet"]/researchPrerequisites</xpath>
+                    <value><li>FlakArmor</li></value>
+                  </li>
+
+                  <li Class="PatchOperationReplace" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CastellanHelmet"]/researchPrerequisite</xpath>
+                    <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CastellanHelmet"][not(researchPrerequisite)]</xpath>
+                    <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CastellanHelmet"][not(researchPrerequisites)]</xpath>
+                    <value>
+                      <researchPrerequisites>
+                        <li>GW_TotE_Castellan</li>
+                        <li>FlakArmor</li>
+                      </researchPrerequisites>
+                    </value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CastellanHelmet"]/researchPrerequisites</xpath>
+                    <value><li>GW_TotE_Castellan</li></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/RecipeDef[defName="Make_GW_HOI_Cadian_CastellanHelmet"]/researchPrerequisites</xpath>
+                    <value><li>FlakArmor</li></value>
+                  </li>
+
+                  <li Class="PatchOperationReplace" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_CadianCommanderArmor"]/recipeMaker/researchPrerequisite</xpath>
+                    <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_CadianCommanderArmor"]/recipeMaker[not(researchPrerequisite)]</xpath>
+                    <value>
+                      <researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite>
+                    </value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_CadianCommanderArmor"]/recipeMaker[not(researchPrerequisites)]</xpath>
+                    <value><researchPrerequisites><li>GW_TotE_Castellan</li></researchPrerequisites></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_CadianCommanderArmor"]/recipeMaker/researchPrerequisites</xpath>
+                    <value><li>GW_TotE_Castellan</li></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_CadianCommanderArmor"]/recipeMaker[not(researchPrerequisites)]</xpath>
+                    <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_CadianCommanderArmor"]/recipeMaker/researchPrerequisites</xpath>
+                    <value><li>FlakArmor</li></value>
+                  </li>
+                  <li Class="PatchOperationReplace" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CastellenHelmet"]/recipeMaker/researchPrerequisite</xpath>
+                    <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CastellenHelmet"]/recipeMaker[not(researchPrerequisite)]</xpath>
+                    <value><researchPrerequisite>GW_AM_MilitariumArmor</researchPrerequisite></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CastellenHelmet"]/recipeMaker[not(researchPrerequisites)]</xpath>
+                    <value><researchPrerequisites><li>GW_TotE_Castellan</li></researchPrerequisites></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CastellenHelmet"]/recipeMaker/researchPrerequisites</xpath>
+                    <value><li>GW_TotE_Castellan</li></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CastellenHelmet"]/recipeMaker[not(researchPrerequisites)]</xpath>
+                    <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CastellenHelmet"]/recipeMaker/researchPrerequisites</xpath>
+                    <value><li>FlakArmor</li></value>
+                  </li>
+                </operations>
+              </match>
+            </li>
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Regiments of Renown ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Regiments of Renown</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- ===== Catachan Jungle Fighters ===== -->
+            <!-- Catachan armor → FlakArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_CatachanArmor"]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <!-- Catachan fang — move to Catachan research, unlocked by GW_Chainswords -->
+            <!-- Source has no recipeMaker — Add a full block with both prereqs -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AM_MeleeWeapon_CatachanFang"]</xpath>
+              <value>
+                <recipeMaker>
+                  <researchPrerequisite>GW_AM_Catachan</researchPrerequisite>
+                  <researchPrerequisites>
+                    <li>GW_Chainswords</li>
+                  </researchPrerequisites>
+                </recipeMaker>
+              </value>
+            </li>
+
+            <!-- ===== Lucifer Blacks ===== -->
+            <!-- Armor → add ReconArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_LuciferBlack_Armor"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <!-- Helmets → add ReconArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_LuciferBlackSkull"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_LuciferBlackAlt"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_LuciferBlackMask"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <!-- Power Glaive + Power Sabre → add GW_PowerMeleeWeapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Melee_PowerGlaive"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Melee_PowerSaber"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Tallarn Desert Raiders ===== -->
+            <!-- Desert Gear → FlakArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_TDR_DesertGear"]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Tanith First and Only ===== -->
+            <!-- Tanith monocular → Gunlink research -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Tanith1stGoggle"]</xpath>
+              <value><researchPrerequisites><li>Gunlink</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Lucifer Blacks ===== -->
+            <!-- Armor + helmets already in RoR block above -->
+            <!-- Hellgun + Hellpistol → MPI_GW_AdvancedLasguns -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Gun_LuciferHellgun"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AdvancedLasguns</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Gun_LuciferPistol"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AdvancedLasguns</li></researchPrerequisites></value>
+            </li>
+            <!-- Bolter → GW_Bolters -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Gun_LuciferBolter"]</xpath>
+              <value><researchPrerequisites><li>GW_Bolters</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Tempestus Scions ===== -->
+            <!-- Helmet already in RoR block above -->
+            <!-- Scion carapace → PoweredArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_TempestusScion_CarapaceArmor"]</xpath>
+              <value><researchPrerequisites><li>PoweredArmor</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Valhallan Ice Warriors ===== -->
+            <!-- Valhallan flak armor → add FlakArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Valhallan_Armor"]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Vostroyan Firstborn ===== -->
+            <!-- Las-lock → move to Tactica Imperium category, unlocked by Gunsmithing -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Gun_lasLock"]/recipeMaker/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_AM_TacticaImperium</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Gun_lasLock"]</xpath>
+              <value><researchPrerequisites><li>Gunsmithing</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Tempestus Scions ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_TempestusScion_Helmet"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Kasrkin Elite Troops ===== -->
+            <!-- Rename Kasrkin vox-caster backpack -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_KarskinVoxBackpack"]/label</xpath>
+              <value><label>Kasrkin vox-caster backpack</label></value>
+            </li>
+            <!-- Kasrkin carapace armor + helmet → add ReconArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_CadianKasrkin_FlakArmor"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_CadianKasrkin_Helmet"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <!-- Kasrkin heavy armor → add CataphractArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_CadianKasrkin_HeavyArmor"]</xpath>
+              <value><researchPrerequisites><li>CataphractArmor</li></researchPrerequisites></value>
+            </li>
+            <!-- Kasrkin backpacks → VAE_MilitaryClothing handled in patchVEHook RoR block -->
+            <!-- Meltagun Cadian pattern → add GW_MeltaWeapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Gun_MeltaGun"]</xpath>
+              <value><researchPrerequisites><li>GW_MeltaWeapons</li></researchPrerequisites></value>
+            </li>
+            <!-- Plasma gun M35 Magnacore → add GW_PlasmaWeapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Gun_PlasmaGun"]</xpath>
+              <value><researchPrerequisites><li>GW_PlasmaWeapons</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Armageddon Steel Legion ===== -->
+            <!-- Voss MKI → add MPI_GW_Lasguns -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Gun_VossPattern"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_Lasguns</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Tanith First and Only ===== -->
+            <!-- Long-las Cadian pattern → unlocked by MPI_GW_AdvancedLasguns -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Gun_Longlas"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AdvancedLasguns</li></researchPrerequisites></value>
+            </li>
+            <!-- Tanith monocular → Gunlink research (already in RoR block below) -->
+
+            <!-- ===== Elysian Drop Troopers ===== -->
+            <!-- Accatran MKIV → MPI_GW_Lasguns -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Gun_Accatranfive"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_Lasguns</li></researchPrerequisites></value>
+            </li>
+            <!-- Accatran plasma → GW_PlasmaWeapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Gun_PlasmaGun"]</xpath>
+              <value><researchPrerequisites><li>GW_PlasmaWeapons</li></researchPrerequisites></value>
+            </li>
+            <!-- Accatran melta → GW_MeltaWeapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Gun_MeltaGun"]</xpath>
+              <value><researchPrerequisites><li>GW_MeltaWeapons</li></researchPrerequisites></value>
+            </li>
+            <!-- Elysian helmet (closed) → ReconArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Elysian_Helmet"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <!-- Elysian helmet (open) + flak armor → FlakArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_ElysianHelmetOpen"]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Elysian_Armor"]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <!-- Elysian jetpack → GW_SM_Jump_Packs if AoD present, else JumpPack -->
+            <li Class="PatchOperationFindMod" MayFail="true">
+              <mods><li>Grimworld 40,000 - Angels of Death</li></mods>
+              <match Class="PatchOperationAdd" MayFail="true">
+                <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Elysian_Jetpack"]</xpath>
+                <value><researchPrerequisites><li>GW_SM_Jump_Packs</li></researchPrerequisites></value>
+              </match>
+              <nomatch Class="PatchOperationAdd" MayFail="true">
+                <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Elysian_Jetpack"]</xpath>
+                <value><researchPrerequisites><li>JumpPack</li></researchPrerequisites></value>
+              </nomatch>
+            </li>
+
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Dead Men of Krieg ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Dead Men</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- ===== Death Korps of Krieg ===== -->
+            <!-- Lucius lasguns → add MPI_GW_Lasguns -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_DM_Gun_Lucius"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_Lasguns</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_DM_Gun_LuciusXIV"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_Lasguns</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_DM_Gun_LuciusHellgun"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_Lasguns</li></researchPrerequisites></value>
+            </li>
+            <!-- Lucius shotgun → add GW_Autoguns -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_DM_Gun_LuciusShotgun"]</xpath>
+              <value><researchPrerequisites><li>GW_Autoguns</li></researchPrerequisites></value>
+            </li>
+            <!-- DK guard helmet → add FlakArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_DM_KriegGuardHelmet"]</xpath>
+              <value><researchPrerequisites><li>FlakArmor</li></researchPrerequisites></value>
+            </li>
+            <!-- DK engineer armor + helmet → add ReconArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_DM_KriegEngineerMiddle"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_DM_KriegEngineerHelmet"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <!-- DK grenadier armor + helmet → add ReconArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_DM_KriegGrenadierArmor"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_DM_KriegGrenadierHelmet"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <!-- DK officer cuirass + helmet → add ReconArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_DM_KriegOfficerArmor"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_DM_KriegOfficerHelmet"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Talons of the Emperor ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Talons of the Emperor</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- ===== TotE Weapons ===== -->
+            <!-- Sentinel Blade → Power Melee Weapons (tooltip only — no recipeMaker in source) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_Sentinel_Blade"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+            <!-- Vaultsword → Aerythmetica Discontinuity (tooltip only — no recipeMaker in source) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_Vaultsword"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AerythmeticaDiscontinuity</li></researchPrerequisites></value>
+            </li>
+            <!-- Vratine Bolter → Advanced Bolters + Force Weaponry -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_SOSBolter"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li>GW_AdvancedBolters</li>
+                  <li>MPI_GW_ForceWeaponry</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+
+            <!-- Guardian Spear → Power Melee Weapons + Advanced Bolters -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_GuardianSpear"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li>GW_PowerMeleeWeapons</li>
+                  <li>GW_AdvancedBolters</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+            <!-- Adrathic Spear → Power Melee Weapons + Aerythmetica Discontinuity -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_AdrathicSpear"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_AdrathicSpear"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AerythmeticaDiscontinuity</li></researchPrerequisites></value>
+            </li>
+            <!-- Kinetic Destroyer → Aerythmetica Discontinuity -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_Kinetic_Destructor"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AerythmeticaDiscontinuity</li></researchPrerequisites></value>
+            </li>
+            <!-- Misericordia → Aerythmetica Discontinuity -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_Misericordia"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AerythmeticaDiscontinuity</li></researchPrerequisites></value>
+            </li>
+            <!-- Pyrithite Spear → Power Melee Weapons + Melta Weapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_MeltaSpear"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li>GW_PowerMeleeWeapons</li>
+                  <li>GW_MeltaWeapons</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+            <!-- Executioner Greatblade → Force Weaponry -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_SoSSword"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_ForceWeaponry</li></researchPrerequisites></value>
+            </li>
+            <!-- Bolt Caliver → Advanced Bolters -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_Bolt_Caliver"]</xpath>
+              <value><researchPrerequisites><li>GW_AdvancedBolters</li></researchPrerequisites></value>
+            </li>
+            <!-- Incendium Firepike → Flamers -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_Firepike"]</xpath>
+              <value><researchPrerequisites><li>GW_Flamers</li></researchPrerequisites></value>
+            </li>
+
+            <!-- Castellan Axe → Basic Melee Weapons + Bolters (stays in Castellan category) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_CastellanAxe"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li>GW_Chainswords</li>
+                  <li>GW_Bolters</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+
+            <!-- Watcher's Axe → Power Melee Weapons + Advanced Bolters (stays in Castellan category) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_WatchersAxe"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li>GW_PowerMeleeWeapons</li>
+                  <li>GW_AdvancedBolters</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+
+            <!-- ===== Allarus Terminator set → Astartes Heavy Armors ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_AllarusArmor"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_AllarusHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_AllarusShoulder"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Custodes Guard tier → Astartes Heavy Armors ===== -->
+            <!-- Blade Champion -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_BladeOfChamp"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_BladeChampHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <!-- Custodes Shield Host -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_CustodesGuardArmor"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_CustodesGuardHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_CustodesGuardShoulder"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <!-- Custodes Warden -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_CustodesWardenArmor"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_CustodesWardenHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_CustodesWardenShoulder"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <!-- Eye of the Emperor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_EyeOfTheEmperor"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_EyeOfTheEmperorHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_EyeoftheEmperorShoulder"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <!-- Sagittarum helmet -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_SagittarumHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <!-- Shield Captain -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_ShieldCaptianHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_ShieldCaptainShoulder"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <!-- Sister of Silence -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_SisterOfSilence"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_SoSHelmetA"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_SoSHelmetB"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_SoSShoulder"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Venatari mask → Astartes Light Armors ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_VenatariHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesLight</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Venatari jump pack → GW_SM_Jump_Packs if AoD present, else JumpPack + label fix ===== -->
+            <li Class="PatchOperationFindMod" MayFail="true">
+              <mods><li>Grimworld 40,000 - Angels of Death</li></mods>
+              <match Class="PatchOperationAdd" MayFail="true">
+                <xpath>Defs/ThingDef[defName="GW_TotE_VenatariBackpack"]</xpath>
+                <value><researchPrerequisites><li>GW_SM_Jump_Packs</li></researchPrerequisites></value>
+              </match>
+              <nomatch Class="PatchOperationAdd" MayFail="true">
+                <xpath>Defs/ThingDef[defName="GW_TotE_VenatariBackpack"]</xpath>
+                <value><researchPrerequisites><li>JumpPack</li></researchPrerequisites></value>
+              </nomatch>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_VenatariBackpack"]/label</xpath>
+              <value><label>Venatari jump pack</label></value>
+            </li>
+
+            <!-- ===== Custodes Shields → Astartes Shields research ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GM_TotE_ShieldPraesidium"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesBasicShields</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GM_TotE_ShieldSCaptain"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesBasicShields</li></researchPrerequisites></value>
+            </li>
+
+            <!-- Castellan Plate, Plate Helmet, Plate Shoulder Pads → require Astartes Heavy Armors -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_CastellanArmor"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_CastellanPlateHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_TotE_CastellanPlateShoulder"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Angels of Death ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>Grimworld 40,000 - Angels of Death</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- ===== Astartes Scout gear → add ReconArmor ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_Scout"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ScoutHelmet_A"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ScoutHelmet_B"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ScoutHelmet_C"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ScoutHelmet_D"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ScoutHelmet_E"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ScoutShoulderPads_TypeA"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ScoutShoulderPads_TypeB"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ScoutShoulderPads_TypeC"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+            <!-- Fibrovest → add ReconArmor -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_FibroVest"]</xpath>
+              <value><researchPrerequisites><li>ReconArmor</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Astartes melee — move to Astartes Fabrication category via recipeMaker ===== -->
+            <!-- Astartes chainsword → Replace recipeMaker prereq to GW_SM_AstartesFabrication -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Chainsword"]/recipeMaker/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_SM_AstartesFabrication</researchPrerequisite></value>
+            </li>
+            <!-- Unlocked with Basic melee weapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Chainsword"]</xpath>
+              <value><researchPrerequisites><li>GW_Chainswords</li></researchPrerequisites></value>
+            </li>
+            <!-- Astartes combat knife → Replace recipeMaker prereq to GW_SM_AstartesFabrication -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_CombatKnife"]/recipeMaker/researchPrerequisite</xpath>
+              <value><researchPrerequisite>GW_SM_AstartesFabrication</researchPrerequisite></value>
+            </li>
+            <!-- Unlocked with Basic melee weapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_CombatKnife"]</xpath>
+              <value><researchPrerequisites><li>GW_Chainswords</li></researchPrerequisites></value>
+            </li>
+
+            <!-- Bolt Pistol (Astartes) → add GW_Bolters to recipeMaker (moves to Bolters category) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Gun_BoltPistol"]/recipeMaker</xpath>
+              <value><researchPrerequisite>GW_Bolters</researchPrerequisite></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_MeltaGun"]/recipeMaker</xpath>
+              <value><researchPrerequisite>GW_MeltaWeapons</researchPrerequisite></value>
+            </li>
+
+            <!-- ===== Astartes power melee + hammers — stay in category, unlocked by PowerMeleeWeapons ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Powersword"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Relic_Powersword"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Powerfist"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_ThunderHammer"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+            <!-- Terminator variants -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_TermPowerFist"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_TermSword"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Term_Thunder1hHammer"]</xpath>
+              <value><researchPrerequisites><li>GW_PowerMeleeWeapons</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Astartes Heavy weapons gates ===== -->
+            <!-- Reaper autocannon → GW_Autoguns + MultibarrelWeapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Gun_ReaperCannon"]</xpath>
+              <value><researchPrerequisites><li>GW_Autoguns</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Gun_ReaperCannon"]</xpath>
+              <value><researchPrerequisites><li>MultibarrelWeapons</li></researchPrerequisites></value>
+            </li>
+            <!-- Assault cannon → Aerythmetica Discontinuity + MultibarrelWeapons (note: typo in source defName) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Gun_AssualtCannon"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AerythmeticaDiscontinuity</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Gun_AssualtCannon"]</xpath>
+              <value><researchPrerequisites><li>MultibarrelWeapons</li></researchPrerequisites></value>
+            </li>
+            <!-- Graviton cannon → Aerythmetica Discontinuity (already gated by AstartesHeavy via recipeMaker) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Gun_GravCannon"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AerythmeticaDiscontinuity</li></researchPrerequisites></value>
+            </li>
+            <!-- Heavy flamer → GW_Flamers -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Gun_HeavyFlamer"]</xpath>
+              <value><researchPrerequisites><li>GW_Flamers</li></researchPrerequisites></value>
+            </li>
+            <!-- Terminator plasma cannon → GW_PlasmaWeapons + MultibarrelWeapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Gun_PlasmaCannon"]</xpath>
+              <value><researchPrerequisites><li>GW_PlasmaWeapons</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Gun_PlasmaCannon"]</xpath>
+              <value><researchPrerequisites><li>MultibarrelWeapons</li></researchPrerequisites></value>
+            </li>
+            <!-- Umbra storm bolter → GW_AdvancedBolters + MultibarrelWeapons -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Gun_StormBolter"]</xpath>
+              <value><researchPrerequisites><li>GW_AdvancedBolters</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Gun_StormBolter"]</xpath>
+              <value><researchPrerequisites><li>MultibarrelWeapons</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Astartes missile launcher → also require Launchers ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_RocketLauncher"]</xpath>
+              <value><researchPrerequisites><li>GW_Launchers</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Graviton rifle + pistol → Aerythmetica Discontinuity ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_Gun_GravRifle"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AerythmeticaDiscontinuity</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_Gun_GravPistol"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AerythmeticaDiscontinuity</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Multi-melta → unlocked by MultibarrelWeapons ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AOD_Multimelta"]</xpath>
+              <value><researchPrerequisites><li>MultibarrelWeapons</li></researchPrerequisites></value>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+
+      <!-- ==================== Scattered Sons ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>Grimworld 40,000 - Scattered Sons</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- ===== Imperial Regent set → Astartes Heavy Armors ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterArmor"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterShoulderPads"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Armor of Fate set → Astartes Heavy Armors ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_GuillimanArmor"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_GuillimanHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_GuillimanShoulderPads"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Emperor's sword → Aerythmetica Discontinuity ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_Melee_FlameSword"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AerythmeticaDiscontinuity</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Imperial Warden armor set → Astartes Heavy Armors ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrArmor"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenHood"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenHooded"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrShoulderPads"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Lion's armor set → Astartes Heavy Armors ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_LionArmor"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_LionArmorHood"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_LionArmorHooded"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_LionArmorHelmet"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_LionArmorShoulderPads"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== Emperor's Shield + Imperial Warden shield → Astartes Shields + Disco ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GM_SS_ShieldLionsW"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesBasicShields</li>
+                  <li>MPI_GW_AerythmeticaDiscontinuity</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GM_SS_ShieldLionsC"]</xpath>
+              <value>
+                <researchPrerequisites>
+                  <li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesBasicShields</li>
+                  <li>MPI_GW_AerythmeticaDiscontinuity</li>
+                </researchPrerequisites>
+              </value>
+            </li>
+
+            <!-- ===== Fealty → Aerythmetica Discontinuity ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SS_LionSword"]</xpath>
+              <value><researchPrerequisites><li>MPI_GW_AerythmeticaDiscontinuity</li></researchPrerequisites></value>
+            </li>
+
+            <!-- ===== All backpacks → Astartes Heavy Armors ===== -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ChapterMasterBackpack"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_GuillimanBackpack"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ImperialWardenrBackpack"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_LionArmorBackpack"]</xpath>
+              <value><researchPrerequisites><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li></researchPrerequisites></value>
+            </li>
+
+
+          </operations>
+        </match>
+      </li>
+	  <!-- ========================== From patchGWResearch ============================== -->
+      <!-- ==================== Masters of Mankind + Angels of Death ==================== -->
+      <!-- Conditional: Salamander prereq for Vulkan's Autoforge only when both active -->
+      <li Class="PatchOperationFindMod" Logic="All">
+        <mods>
+          <li>GrimWorld 40,000 - Masters of Mankind</li>
+          <li>Grimworld 40,000 - Angels of Death</li>
+        </mods>
+        <match Class="PatchOperationAdd">
+          <xpath>Defs/ResearchProjectDef[defName="GW_Rulers_MasterForge"]/prerequisites</xpath>
+          <value><li MayRequire="happypurging.ageofdarkness">GW_SM_Salamander</li></value>
+        </match>
+      </li>
+      <!-- Disco prereq for Vulkan's Autoforge whenever Masters of Mankind is active -->
+      <li Class="PatchOperationFindMod" MayFail="true">
+        <mods><li>GrimWorld 40,000 - Masters of Mankind</li></mods>
+        <match Class="PatchOperationAdd" MayFail="true">
+          <xpath>Defs/ResearchProjectDef[defName="GW_Rulers_MasterForge"]/prerequisites</xpath>
+          <value><li>MPI_GW_AerythmeticaDiscontinuity</li></value>
+        </match>
+      </li>
+	  
+      <!-- ==================== PREREQUISITE ADDITIONS ==================== -->
+
+      <!-- f GW_AM_MilitariumArmor — requires ComplexClothing -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_MilitariumArmor"]/prerequisites</xpath>
+        <value><li>ComplexClothing</li></value>
+      </li>
+
+      <!-- f GW_PlasmaWeapons — requires Astartes Fabrication if Angels of Death present -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_PlasmaWeapons"]/prerequisites</xpath>
+        <value><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesFabrication</li></value>
+      </li>
+
+      <!-- f GW_Bolters — requires Regiments of Renown -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Bolters"]/prerequisites</xpath>
+        <value><li MayRequire="Grimworld.AstraMilitarum">GW_AM_RegimentsOfRenown</li></value>
+      </li>
+
+      <!-- f GW_Flamers — requires Regiments of Renown -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Flamers"]/prerequisites</xpath>
+        <value><li MayRequire="Grimworld.AstraMilitarum">GW_AM_RegimentsOfRenown</li></value>
+      </li>
+
+      <!-- f GW_GrimworldMaterials — requires Imperial Fortifications -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GrimworldMaterials"]/prerequisites</xpath>
+        <value><li MayRequire="Grimworld.AstraMilitarum">GW_AM_ImperiumDefense</li></value>
+      </li>
+
+      <!-- f GW_Autoguns — requires Tactica Imperium -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Autoguns"]/prerequisites</xpath>
+        <value><li MayRequire="Grimworld.AstraMilitarum">GW_AM_TacticaImperium</li></value>
+      </li>
+
+      <!-- f GW_Launchers — requires Tactica Imperium -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Launchers"]/prerequisites</xpath>
+        <value><li MayRequire="Grimworld.AstraMilitarum">GW_AM_TacticaImperium</li></value>
+      </li>
+
+      <!-- GW_Chainswords — requires Tactica Imperium -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Chainswords"]/prerequisites</xpath>
+        <value><li MayRequire="Grimworld.AstraMilitarum">GW_AM_TacticaImperium</li></value>
+      </li>
+
+		<!-- GW_AM_BasicImperiumDefense — prereq -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_BasicImperiumDefense"]/prerequisites</xpath>
+        <value><li MayRequire="Grimworld.AstraMilitarum">GW_AM_TacticaImperium</li></value>
+      </li>		
+		
+		<!-- GW_AM_ImperiumDefense — prereq -->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_ImperiumDefense"]/prerequisites</xpath>
+        <value>
+          <prerequisites>
+            <li>GW_AM_BasicImperiumDefense</li>
+            <li>Machining</li>
+          </prerequisites>
+        </value>
+      </li>
+      <!-- GW_BlastDoors — add ImperiumDefense prereq -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_BlastDoors"]/prerequisites</xpath>
+        <value><li>GW_AM_ImperiumDefense</li></value>
+      </li>
+
+      <!-- GW_DrugProduction — replace prereqs -->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_DrugProduction"]/prerequisites</xpath>
+        <value>
+          <prerequisites>
+            <li>DrugProduction</li>
+            <li MayRequire="Grimworld.AstraMilitarum">GW_AM_TacticaImperium</li>
+          </prerequisites>
+        </value>
+      </li>
+
+      <!-- GW_AM_TacticaImperium — add GeneSeeding prereq, remove Electronics this section came from patchGWResearch MOVED TO patchGWGene -->
+      <!--<li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_TacticaImperium"]/prerequisites</xpath>
+        <value><li MayRequire="Grimworld.Core">GW_GeneSeeding</li></value>
+      </li>
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_TacticaImperium"]/prerequisites/li[.="Electricity"]</xpath>
+      </li> -->
+	 
+
+      <!-- GW_IF_CommonStuff — add TacticaImperium prereq -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_IF_CommonStuff"]/prerequisites</xpath>
+        <value><li MayRequire="Grimworld.AstraMilitarum">GW_AM_TacticaImperium</li></value>
+      </li>
+
+      <!-- GW_SM_CodexAstartes — add RegimentsOfRenown prereq -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_CodexAstartes"]/prerequisites</xpath>
+        <value><li MayRequire="Grimworld.AstraMilitarum">GW_AM_RegimentsOfRenown</li></value>
+      </li>
+
+      <!-- GW_SM_NightLord — only AstartesHeavy prereq -->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_NightLord"]/prerequisites</xpath>
+        <value>
+          <prerequisites>
+            <li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li>
+          </prerequisites>
+        </value>
+      </li>
+
+      <!-- GW_SM_Salamander — only AstartesHeavy prereq -->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_Salamander"]/prerequisites</xpath>
+        <value>
+          <prerequisites>
+            <li MayRequire="HappyPurging.AgeofDarkness">GW_SM_AstartesHeavy</li>
+          </prerequisites>
+        </value>
+      </li>
+
+      <!-- GW_Primarchfabrication — require AdvancedFabrication always;
+           CustodesFabrication if Talons present -->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Primarchfabrication"]/prerequisites</xpath>
+        <value>
+          <prerequisites>
+            <li>AdvancedFabrication</li>
+            <li MayRequire="grimworld.talonOfTheEmperor">GW_TotE_CustodesFabrication</li>
+          </prerequisites>
+        </value>
+      </li>
+
+      <!-- GW_TotE_CustodesFabrication — add Cogitator as prerequisite -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_TotE_CustodesFabrication"]/prerequisites</xpath>
+        <value><li>GW_Cogitator</li></value>
+      </li>
+
+      <!-- GW_PlasmaReactor — require AdvancedFabrication only (remove Electricity) -->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_PlasmaReactor"]/prerequisites</xpath>
+        <value>
+          <prerequisites>
+            <li>AdvancedFabrication</li>
+          </prerequisites>
+        </value>
+      </li>
+
+      <!-- GW_Cogitator — require AdvancedFabrication only (remove MultiAnalyzer) -->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Cogitator"]/prerequisites</xpath>
+        <value>
+          <prerequisites>
+            <li>AdvancedFabrication</li>
+          </prerequisites>
+        </value>
+      </li>
+
+      <!-- GW_Autoguns — remove Gunsmithing, add BlowbackOperation -->
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Autoguns"]/prerequisites/li[.="Gunsmithing"]</xpath>
+      </li>
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Autoguns"]/prerequisites</xpath>
+        <value><li>BlowbackOperation</li></value>
+      </li>
+
+      <!-- GW_Flamers — remove Gunsmithing, add GasOperation -->
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Flamers"]/prerequisites/li[.="Gunsmithing"]</xpath>
+      </li>
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Flamers"]/prerequisites</xpath>
+        <value><li>GasOperation</li></value>
+      </li>
+
+      <!-- GW_Launchers — add MicroelectronicsBasics -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Launchers"]/prerequisites</xpath>
+        <value><li>MicroelectronicsBasics</li></value>
+      </li>
+
+      <!-- GW_PlasmaWeapons — remove Gunsmithing, add GasOperation + AdvancedFabrication -->
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_PlasmaWeapons"]/prerequisites/li[.="Gunsmithing"]</xpath>
+      </li>
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_PlasmaWeapons"]/prerequisites</xpath>
+        <value><li>GasOperation</li></value>
+      </li>
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_PlasmaWeapons"]/prerequisites</xpath>
+        <value><li>AdvancedFabrication</li></value>
+      </li>
+
+      <!-- GW_MeltaWeapons — add Fabrication + TacticaImperium -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_MeltaWeapons"]/prerequisites</xpath>
+        <value><li>Fabrication</li></value>
+      </li>
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_MeltaWeapons"]/prerequisites</xpath>
+        <value><li MayRequire="Grimworld.AstraMilitarum">GW_AM_TacticaImperium</li></value>
+      </li>
+
+      <!-- GW_AdvancedGrimworldMaterials — remove Fabrication prereq, rename, new description -->
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AdvancedGrimworldMaterials"]/prerequisites/li[.="Fabrication"]</xpath>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AdvancedGrimworldMaterials"]/label</xpath>
+        <value><label>Rites of the Omnissiah</label></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AdvancedGrimworldMaterials"]/description</xpath>
+        <value><description>Through sacred rite and ancient liturgy, your tech-adepts have unlocked the knowledge to fabricate Relic Components — fragments of a bygone age when the Imperium's technological mastery was without equal. These are not merely manufactured; they are consecrated. Each component is assembled through a series of devotional rituals passed down through the Adeptus Mechanicus, invoking the blessing of the Omnissiah upon each part. To produce such components without proper sanctification would be not merely wasteful, but heretical.</description></value>
+      </li>
+
+      <!-- GW_RepairBench — add AdvancedFabrication, remove Electricity -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_RepairBench"]/prerequisites</xpath>
+        <value><li>AdvancedFabrication</li></value>
+      </li>
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_RepairBench"]/prerequisites/li[.="Electricity"]</xpath>
+      </li>
+
+      <!-- GW_Bolters — add BlowbackOperation -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Bolters"]/prerequisites</xpath>
+        <value><li>BlowbackOperation</li></value>
+      </li>
+
+      <!-- GW_AdvancedBolters — add GasOperation -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AdvancedBolters"]/prerequisites</xpath>
+        <value><li>GasOperation</li></value>
+      </li>
+
+      <!-- GW_SM_AstartesLight → also require ReconArmor -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesLight"]/prerequisites</xpath>
+        <value><li>ReconArmor</li></value>
+      </li>
+
+      <!-- GW_SM_AstartesMedium → also require PoweredArmor -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesMedium"]/prerequisites</xpath>
+        <value><li>PoweredArmor</li></value>
+      </li>
+
+      <!-- GW_SM_Jump_Packs → add vanilla JumpPack as prerequisite (AoD) -->
+      <li Class="PatchOperationFindMod" MayFail="true">
+        <mods><li>Grimworld 40,000 - Angels of Death</li></mods>
+        <match Class="PatchOperationAdd" MayFail="true">
+          <xpath>Defs/ResearchProjectDef[defName="GW_SM_Jump_Packs"]/prerequisites</xpath>
+          <value><li>JumpPack</li></value>
+        </match>
+      </li>
+
+      <!-- GW_SM_AstartesHeavy → also require CataphractArmor -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesHeavy"]/prerequisites</xpath>
+        <value><li>CataphractArmor</li></value>
+      </li>
+
+      <!-- GW_SM_CodexAstartes — change AdvancedFabrication prereq to Fabrication -->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_CodexAstartes"]/prerequisites/li[.="AdvancedFabrication"]</xpath>
+        <value><li>Fabrication</li></value>
+      </li>
+
+		
+    </operations>
+  </Operation>
+
+</Patch>

--- a/1.6/Patches/patchGWCat.xml
+++ b/1.6/Patches/patchGWCat.xml
@@ -1,0 +1,541 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ============================================================ -->
+<!-- patchGWCat.xml                                               -->
+<!-- Moves Grimworld items into appropriate vanilla categories.   -->
+<!-- Each section uses a single FindMod + PatchOperationSequence  -->
+<!-- with MayFail="true" on each individual operation inside so   -->
+<!-- one failure never aborts the rest.                           -->
+<!-- ============================================================ -->
+<Patch>
+
+  <Operation Class="GW_Frame.PatchOperation_GWPatch">
+    <patchName>GWCat</patchName>
+    <operations>
+
+      <!-- ==================== Core Imperialis ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Core Imperialis</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- Walls → Structure -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_Wall"]/designationCategory</xpath>
+              <value><designationCategory>Structure</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_ReinforcedWall"]/designationCategory</xpath>
+              <value><designationCategory>Structure</designationCategory></value>
+            </li>
+
+            <!-- Embrasures → Structure -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Embrasure"]/designationCategory</xpath>
+              <value><designationCategory>Structure</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_EmbrasureArmored"]/designationCategory</xpath>
+              <value><designationCategory>Structure</designationCategory></value>
+            </li>
+
+            <!-- Doors → Structure (Add since inherited from abstract parent) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_ImperialisDoor"]</xpath>
+              <value><designationCategory>Structure</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_ImperialisAutodoor"]</xpath>
+              <value><designationCategory>Structure</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_MechanicusDoor"]</xpath>
+              <value><designationCategory>Structure</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_MechanicusAutodoor"]</xpath>
+              <value><designationCategory>Structure</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_BlastDoor"]</xpath>
+              <value><designationCategory>Structure</designationCategory></value>
+            </li>
+
+            <!-- Barbed wire → Security -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="DefensiveBarbedWire"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+
+            <!-- Tank traps → Security -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="DefensiveTankTrapA"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="DefensiveTankTrapB"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+
+            <!-- Repair bench → Production -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_RepairBench"]/designationCategory</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+
+            <!-- Plasma generator → Power -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_PlasmaGenerator"]/designationCategory</xpath>
+              <value><designationCategory>Power</designationCategory></value>
+            </li>
+
+            <!-- Furnace → Production -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_Furnace"]/designationCategory</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+
+            <!-- Cogitator → Production -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_Cogitator"]/designationCategory</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+
+            <!-- Warhammer table → Joy -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_WarhammerTable"]/designationCategory</xpath>
+              <value><designationCategory>Joy</designationCategory></value>
+            </li>
+
+            <!-- Imperial Tool Cabinet → Misc -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_VehicleToolCabinet"]/designationCategory</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+
+            <!-- Remove GrimworldCategory -->
+            <li Class="PatchOperationRemove" MayFail="true">
+              <xpath>Defs/DesignationCategoryDef[defName="GrimworldCategory"]</xpath>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Hammer of the Imperium ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Hammer of the Imperium</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- Militarum workbenches → Production (Add since inherited from abstract parent) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="HP_AM_MilitarumFabricationBench"]</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_AM_MilitarumArmorBench"]</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+
+            <!-- Turrets → Security (designationCategory on concrete def → Replace) -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Building_HeavyBolter"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Building_Autocannon"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Building_Lascannon"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Building_TarantulaHeavyBolter"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Building_TarantulaLascannon"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_HOI_Turret_Earthshaker"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+
+            <!-- Trenches → Security (designationCategory on concrete def → Replace) -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_Trenches"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="TrenchBarricade"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Aspectus Imperialis ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Aspectus Imperialis</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- Wall lamp → Furniture -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_WallLamp"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+			            <!-- All candles → Furniture -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_Candle"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+			
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_CandlesWax"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_CandleSkull"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+
+            <!-- Candelabra — Furniture -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_Candelabra"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+
+            <!-- CandleStand — Furniture -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_CandleStand"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+
+            <!-- Gates → Structure
+                 GW40k_2x1Gate and GW40k_3x1Gate: designationCategory on concrete def → Replace -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_2x1Gate"]/designationCategory</xpath>
+              <value><designationCategory>Structure</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_3x1Gate"]/designationCategory</xpath>
+              <value><designationCategory>Structure</designationCategory></value>
+            </li>
+
+            <!-- Royal tables + chairs → Furniture
+                 GW_IF_Royal_1x1c..3x3c and GW_IF_Royal_Chair: designationCategory on concrete def → Replace -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_Royal_1x1c"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_Royal_2x1c"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_Royal_2x2c"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_Royal_2x4c"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_Royal_3x3c"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_Royal_Chair"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+
+            <!-- Statues → Art
+                 All statue defs have designationCategory COMMENTED OUT in GW source.
+                 Replace will find nothing. Use Add instead. -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_Statues_1x1Janitor"]</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_Statues_1x1Sister"]</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_Statues_1x1Flag"]</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_1x1StatuesHoodGuy"]</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_1x1StatuesOfficer"]</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_1x1StatuesSisterMace"]</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_2x2Statues"]</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_3x3Statues"]</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_4x4StatuesGuil"]</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_4x4StatuesLion"]</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW40k_4x4StatuesVald"]</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+
+            <!-- Golden Throne (Imperial psythrone) → Furniture
+                 GWGT_GoldenThrone: designationCategory on concrete def → Replace -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GWGT_GoldenThrone"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+
+            <!-- Beds → Furniture
+                 All GW_IF bed defs have designationCategory on the concrete def → Replace.
+                 GW_IF_UpperHivebed is commented out in GW source — skipped. -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_CommonSingle"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_CommonDouble"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_PrisonerSingle"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_RoyalSingle"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_RoyalDouble"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_MedicaeBed"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+
+            <!-- Hearths → Furniture
+                 designationCategory is on the ABSTRACT parent GW_IF_Hearth, NOT the concrete defs.
+                 Replace on the concrete def xpath would find nothing — use Add. -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_Hearth"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_RoyalHearth"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+
+            <!-- Rugs → Furniture
+                 designationCategory is on the ABSTRACT parent GW_IF_RugBase, NOT the concrete defs.
+                 Replace on the concrete def xpath would find nothing — use Add. -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_4x4MundaneRug"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_4x6MundaneRug"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_3x6MundaneRug"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_8x8MundaneRug"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_4x4RoyalRug"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_4x6RoyalRug"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_3x6RoyalRug"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_8x8RoyalRug"]</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+
+            <!-- Tables + chairs → Furniture
+                 All have designationCategory on the concrete def → Replace. -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_1x1c"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_2x1c"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_2x2c"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_2x4c"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_3x3c"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_IF_Chair"]/designationCategory</xpath>
+              <value><designationCategory>Furniture</designationCategory></value>
+            </li>
+
+            <!-- Remove GW_IF_Furniture -->
+            <li Class="PatchOperationRemove" MayFail="true">
+              <xpath>Defs/DesignationCategoryDef[defName="GW_IF_Furniture"]</xpath>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Angels of Death ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>Grimworld 40,000 - Angels of Death</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- Astartes workbenches → Production
+                 Inherit from GrimworldFabricationBenchBase (no designationCategory on concrete def) → Add -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="HP_ImperialFabricationBench"]</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ArmorBench"]</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+
+            <!-- Astartes turrets → Security (designationCategory on concrete def → Replace) -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_Building_HeavyBolter"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_Building_Lascannon"]/designationCategory</xpath>
+              <value><designationCategory>Security</designationCategory></value>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Talons of the Emperor ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Talons of the Emperor</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- Talons workbenches → Production
+                 Inherit from GrimworldFabricationBenchBase (no designationCategory on concrete def) → Add -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_TalonOfTheEmperor_ArmorBench"]</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_TalonOfTheEmperor_WeaponBench"]</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Scattered Sons ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>Grimworld 40,000 - Scattered Sons</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- Scattered Sons workbenches → Production
+                 Inherit from GrimworldFabricationBenchBase (no designationCategory on concrete def) → Add -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ScatteredSons_ArmorBench"]</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_SM_ScatteredSons_WeaponBench"]</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Masters of Mankind ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Masters of Mankind</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- Vulkan's Autoforge → Production
+                 designationCategory on concrete def → Replace -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_Autoforge"]/designationCategory</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Vehicle Framework ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>Vehicle Framework</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- GW_GarageDoor abstract → Structure
+                 designationCategory on abstract parent — Add covers all 12
+                 garage door variants (4x1/5x1/7x1 Closed+Open, manual+auto) -->
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ThingDef[@Name="GW_GarageDoor"]</xpath>
+              <value><designationCategory>Structure</designationCategory></value>
+            </li>
+
+            <!-- GW_VehicleBench → Production
+                 designationCategory on concrete def → Replace -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="GW_VehicleBench"]/designationCategory</xpath>
+              <value><designationCategory>Production</designationCategory></value>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+    </operations>
+  </Operation>
+
+</Patch>

--- a/1.6/Patches/patchGWGene.xml
+++ b/1.6/Patches/patchGWGene.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ============================================================ -->
+<!-- patchGWGene.xml                                              -->
+<!-- subset of GW Balance Patch.                                  -->
+<!-- Handles presence of Gene Seeding                             -->
+<!-- ============================================================ -->
+<Patch>
+
+  <Operation Class="GW_Frame.PatchOperation_GWPatch">
+    <patchName>GWGene</patchName>
+    <operations>
+                 <!-- GW_GeneSeeding — unlock and reposition  --> 
+	  <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GeneSeeding"]/researchViewX</xpath>
+        <value><researchViewX>0.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GeneSeeding"]/researchViewY</xpath>
+        <value><researchViewY>0.00</researchViewY></value>
+      </li>
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GeneSeeding"]/requiredResearchBuilding</xpath>
+      </li>
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GeneSeeding"]</xpath>
+        <value>
+          <requiredResearchBuilding MayRequire="Ludeon.RimWorld.Biotech">HiTechResearchBench</requiredResearchBuilding>
+          <requiredResearchFacilities MayRequire="Ludeon.RimWorld.Biotech">
+            <li>MultiAnalyzer</li>
+          </requiredResearchFacilities>
+        </value>
+      </li>	
+
+      <!-- GW_AM_TacticaImperium — add GeneSeeding prereq, remove Electronics -->
+      
+		<li Class="PatchOperationFindMod">
+		  <mods>
+			<li>GrimWorld 40,000 - Hammer of the Imperium</li>
+		  </mods>
+		  <match Class="PatchOperationSequence">
+			<operations>
+			  <li Class="PatchOperationAdd" MayFail="true">
+				<xpath>Defs/ResearchProjectDef[defName="GW_AM_TacticaImperium"]/prerequisites</xpath>
+				<value>
+				  <li MayRequire="grimworld.astramilitarum">GW_GeneSeeding</li> <!-- removed  MayRequire="Grimworld.Core" -->
+				</value>
+			  </li>
+			  <li Class="PatchOperationRemove" MayFail="true">
+				<xpath>Defs/ResearchProjectDef[defName="GW_AM_TacticaImperium"]/prerequisites/li[.="Electricity"]</xpath>
+			  </li>
+			</operations>
+		  </match>
+		</li>	   
+
+	  
+    </operations>
+  </Operation>
+
+</Patch>

--- a/1.6/Patches/patchGWResearch.xml
+++ b/1.6/Patches/patchGWResearch.xml
@@ -1,0 +1,782 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ============================================================ -->
+<!-- patchGWResearch.xml                                          -->
+<!-- Better GW Research patch.                                    -->
+<!-- Position changes use flat MayFail replaces — no FindMod      -->
+<!-- needed since defs are spread across multiple mods.           -->
+<!-- Prerequisite changes still use FindMod to gate correctly.    -->
+<!-- ============================================================ -->
+<Patch>
+
+  <Operation Class="GW_Frame.PatchOperation_GWPatch">
+    <patchName>GWResearch</patchName>
+    <operations>
+
+      <!-- ==================== Core Imperialis ==================== -->
+      <!-- FindMod kept only as a structural marker — all operations -->
+      <!-- moved to flat section below for reliable application      -->
+	  
+      <!-- MOVED TO OWN PATCH <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Core Imperialis</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ResearchProjectDef[defName="GW_GeneSeeding"]/researchViewX</xpath>
+              <value><researchViewX>0.00</researchViewX></value>
+            </li>
+          </operations>
+        </match>
+      </li> -->
+
+
+      <!-- ==================== Vehicle Framework ==================== -->
+      <!-- Prereq (CodexAstartes on GW_VehiclesOfGrimworld) handled in C# via LongEventHandler -->
+      <!-- Positions use flat MayFail replaces — these work because GW_VehiclesOfGrimworld      -->
+      <!-- is a GW Core def; the VF loadFolders defs below also apply flat.                     -->
+
+      <!-- GW_VehiclesOfGrimworld → require Imperium Materials + Codex Astartes (GW Core def — XML timing OK) -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_VehiclesOfGrimworld"]/prerequisites</xpath>
+        <value><li>GW_GrimworldMaterials</li></value>
+      </li>
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_VehiclesOfGrimworld"]/prerequisites</xpath>
+        <value><li MayRequire="HappyPurging.AgeofDarkness">GW_SM_CodexAstartes</li></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GrimworldMaterials"]/researchViewX</xpath>
+        <value><researchViewX>5.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GrimworldMaterials"]/researchViewY</xpath>
+        <value><researchViewY>0.60</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_VehiclesOfGrimworld"]/researchViewX</xpath>
+        <value><researchViewX>6.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_VehiclesOfGrimworld"]/researchViewY</xpath>
+        <value><researchViewY>0.80</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialLandVehicleResearch"]</xpath>
+        <value><researchViewX>8.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialLandVehicleResearch"]/researchViewY</xpath>
+        <value><researchViewY>0.00</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialLandMilitaryLightVehicleResearch"]</xpath>
+        <value><researchViewX>9.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialLandMilitaryLightVehicleResearch"]/researchViewY</xpath>
+        <value><researchViewY>0.00</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialLandMilitaryMediumVehicleResearch"]</xpath>
+        <value><researchViewX>10.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialLandMilitaryMediumVehicleResearch"]/researchViewY</xpath>
+        <value><researchViewY>0.00</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialLandMilitaryHeavyVehicleResearch"]</xpath>
+        <value><researchViewX>11.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialLandMilitaryHeavyVehicleResearch"]/researchViewY</xpath>
+        <value><researchViewY>0.00</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialLandMilitaryEliteVehicleResearch"]</xpath>
+        <value><researchViewX>12.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialLandMilitaryEliteVehicleResearch"]/researchViewY</xpath>
+        <value><researchViewY>0.00</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialLandMilitaryTitanicVehicleResearch"]</xpath>
+        <value><researchViewX>13.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialLandMilitaryTitanicVehicleResearch"]/researchViewY</xpath>
+        <value><researchViewY>0.00</researchViewY></value>
+      </li>
+
+      <!-- Air vehicle X positions — must patch abstract parents since concrete defs inherit X from them -->
+      <li Class="PatchOperationReplace" MayFail="true"> <!-- basic air -->
+        <xpath>Defs/ResearchProjectDef[@Name="GW_Tier1AirVehicleResearch"]/researchViewX</xpath>
+        <value><researchViewX>10.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true"> <!-- advanced air -->
+        <xpath>Defs/ResearchProjectDef[@Name="GW_Tier2AirMilitaryVehicleResearch"]/researchViewX</xpath>
+        <value><researchViewX>11.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true"> <!-- ultimate air -->
+        <xpath>Defs/ResearchProjectDef[@Name="GW_Tier3AirMilitaryVehicleResearch"]/researchViewX</xpath>
+        <value><researchViewX>12.00</researchViewX></value>
+      </li>
+
+      <!-- Air vehicle Y positions — concrete defs define researchViewY themselves → Replace works fine -->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialAirVehicleResearch"]/researchViewY</xpath>
+        <value><researchViewY>0.60</researchViewY></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialAirMilitaryVehicleResearch"]/researchViewY</xpath>
+        <value><researchViewY>0.70</researchViewY></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_ImperialAirMilitaryEliteVehicleResearch"]/researchViewY</xpath>
+        <value><researchViewY>0.70</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GrimworldMaterials"]/researchViewX</xpath>
+        <value><researchViewX>5.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GrimworldMaterials"]/researchViewY</xpath>
+        <value><researchViewY>0.60</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AdvancedGrimworldMaterials"]/researchViewX</xpath>
+        <value><researchViewX>7.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AdvancedGrimworldMaterials"]/researchViewY</xpath>
+        <value><researchViewY>0.10</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_DrugProduction"]/researchViewX</xpath>
+        <value><researchViewX>2.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_DrugProduction"]/researchViewY</xpath>
+        <value><researchViewY>1.80</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_PlasmaReactor"]/researchViewX</xpath>
+        <value><researchViewX>8.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_PlasmaReactor"]/researchViewY</xpath>
+        <value><researchViewY>4.10</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Cogitator"]/researchViewX</xpath>
+        <value><researchViewX>7.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Cogitator"]/researchViewY</xpath>
+        <value><researchViewY>4.80</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_RepairBench"]/researchViewX</xpath>
+        <value><researchViewX>6.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_RepairBench"]/researchViewY</xpath>
+        <value><researchViewY>4.40</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Chainswords"]/researchViewX</xpath>
+        <value><researchViewX>2.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Chainswords"]/researchViewY</xpath>
+        <value><researchViewY>5.60</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_PowerMeleeWeapons"]/researchViewX</xpath>
+        <value><researchViewX>3.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_PowerMeleeWeapons"]/researchViewY</xpath>
+        <value><researchViewY>5.60</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_PlasmaWeapons"]/researchViewX</xpath>
+        <value><researchViewX>8.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_PlasmaWeapons"]/researchViewY</xpath>
+        <value><researchViewY>3.00</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_MeltaWeapons"]/researchViewX</xpath>
+        <value><researchViewX>3.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_MeltaWeapons"]/researchViewY</xpath>
+        <value><researchViewY>4.30</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Launchers"]/researchViewX</xpath>
+        <value><researchViewX>2.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Launchers"]/researchViewY</xpath>
+        <value><researchViewY>4.80</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Flamers"]/researchViewX</xpath>
+        <value><researchViewX>5.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Flamers"]/researchViewY</xpath>
+        <value><researchViewY>4.30</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Bolters"]/researchViewX</xpath>
+        <value><researchViewX>5.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Bolters"]/researchViewY</xpath>
+        <value><researchViewY>4.90</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AdvancedBolters"]/researchViewX</xpath>
+        <value><researchViewX>6.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AdvancedBolters"]/researchViewY</xpath>
+        <value><researchViewY>4.90</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Autoguns"]/researchViewX</xpath>
+        <value><researchViewX>2.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Autoguns"]/researchViewY</xpath>
+        <value><researchViewY>4.20</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_BasicImperiumDefense"]/researchViewX</xpath>
+        <value><researchViewX>2.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_BasicImperiumDefense"]/researchViewY</xpath>
+        <value><researchViewY>0.10</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_ImperiumDefense"]/researchViewX</xpath>
+        <value><researchViewX>4.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_ImperiumDefense"]/researchViewY</xpath>
+        <value><researchViewY>0.10</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_BlastDoors"]/researchViewX</xpath>
+        <value><researchViewX>5.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_BlastDoors"]/researchViewY</xpath>
+        <value><researchViewY>0.10</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_TacticaImperium"]/researchViewX</xpath>
+        <value><researchViewX>1.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_TacticaImperium"]/researchViewY</xpath>
+        <value><researchViewY>2.40</researchViewY></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_MilitariumArmor"]/researchViewX</xpath>
+        <value><researchViewX>2.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_MilitariumArmor"]/researchViewY</xpath>
+        <value><researchViewY>3.00</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_RegimentsOfRenown"]/researchViewX</xpath>
+        <value><researchViewX>3.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_RegimentsOfRenown"]/researchViewY</xpath>
+        <value><researchViewY>3.00</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_OfficersOfAM"]/researchViewX</xpath>
+        <value><researchViewX>6.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_OfficersOfAM"]/researchViewY</xpath>
+        <value><researchViewY>2.00</researchViewY></value>
+      </li>
+	  
+      <!-- ==================== More ==================== -->
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_DeathKorpsOfKrieg"]</xpath>
+        <value><researchViewX>5.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_DeathKorpsOfKrieg"]/researchViewY</xpath>
+        <value><researchViewY>2.60</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_Catachan"]</xpath>
+        <value><researchViewX>4.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_Catachan"]/researchViewY</xpath>
+        <value><researchViewY>2.60</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_TallarnDesertRaiders"]</xpath>
+        <value><researchViewX>4.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_TallarnDesertRaiders"]/researchViewY</xpath>
+        <value><researchViewY>1.90</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_Mordian"]</xpath>
+        <value><researchViewX>5.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_Mordian"]/researchViewY</xpath>
+        <value><researchViewY>3.80</researchViewY></value>
+      </li>
+      <!-- GW_AM_Mordian — reduce cost to 1000 -->
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_Mordian"][not(baseCost)]</xpath>
+        <value><baseCost>1000</baseCost></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_Mordian"]/baseCost</xpath>
+        <value><baseCost>1000</baseCost></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_ElysianDropTroopers"]/researchViewX</xpath>
+        <value><researchViewX>6.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_ElysianDropTroopers"]/researchViewY</xpath>
+        <value><researchViewY>2.70</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_Valhallan"]</xpath>
+        <value><researchViewX>4.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_Valhallan"]/researchViewY</xpath>
+        <value><researchViewY>3.30</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_CadianShockTroops"]</xpath>
+        <value><researchViewX>5.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_CadianShockTroops"]/researchViewY</xpath>
+        <value><researchViewY>3.20</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_VostoyanFirstborn"]</xpath>
+        <value><researchViewX>4.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_VostoyanFirstborn"]/researchViewY</xpath>
+        <value><researchViewY>3.80</researchViewY></value>
+      </li>
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_VostoyanFirstborn"][not(baseCost)]</xpath>
+        <value><baseCost>1000</baseCost></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_VostoyanFirstborn"]/baseCost</xpath>
+        <value><baseCost>1000</baseCost></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_SteelLegion"]</xpath>
+        <value><researchViewX>4.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_SteelLegion"]/researchViewY</xpath>
+        <value><researchViewY>4.30</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_TempestusScions"]</xpath>
+        <value><researchViewX>6.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_TempestusScions"]/researchViewY</xpath>
+        <value><researchViewY>3.90</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_LuciferBlack"]/researchViewX</xpath>
+        <value><researchViewX>6.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_LuciferBlack"]/researchViewY</xpath>
+        <value><researchViewY>3.40</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Tanith1st"]/researchViewX</xpath>
+        <value><researchViewX>5.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Tanith1st"]/researchViewY</xpath>
+        <value><researchViewY>2.10</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_IF_CommonStuff"]/researchViewX</xpath>
+        <value><researchViewX>2.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_IF_CommonStuff"]/researchViewY</xpath>
+        <value><researchViewY>1.20</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_IF_RoyalStuff"]/researchViewX</xpath>
+        <value><researchViewX>4.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_IF_RoyalStuff"]/researchViewY</xpath>
+        <value><researchViewY>1.20</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GoldenThrone"]/researchViewX</xpath>
+        <value><researchViewX>7.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GoldenThrone"]/researchViewY</xpath>
+        <value><researchViewY>1.20</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_CodexAstartes"]/researchViewX</xpath>
+        <value><researchViewX>5.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_CodexAstartes"]/researchViewY</xpath>
+        <value><researchViewY>1.50</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesFabrication"]/researchViewX</xpath>
+        <value><researchViewX>6.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesFabrication"]/researchViewY</xpath>
+        <value><researchViewY>1.50</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_Jump_Packs"]/researchViewX</xpath>
+        <value><researchViewX>8.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_Jump_Packs"]/researchViewY</xpath>
+        <value><researchViewY>1.90</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesBasicShields"]/researchViewX</xpath>
+        <value><researchViewX>8.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesBasicShields"]/researchViewY</xpath>
+        <value><researchViewY>2.40</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesLight"]/researchViewX</xpath>
+        <value><researchViewX>8.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesLight"]/researchViewY</xpath>
+        <value><researchViewY>1.40</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesMedium"]/researchViewX</xpath>
+        <value><researchViewX>9.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesMedium"]/researchViewY</xpath>
+        <value><researchViewY>1.40</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesHeavy"]/researchViewX</xpath>
+        <value><researchViewX>10.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_AstartesHeavy"]/researchViewY</xpath>
+        <value><researchViewY>1.40</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_Ultarmarines"]/researchViewX</xpath>
+        <value><researchViewX>10.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_Ultarmarines"]/researchViewY</xpath>
+        <value><researchViewY>2.20</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_DarkAngels"]/researchViewX</xpath>
+        <value><researchViewX>10.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_DarkAngels"]/researchViewY</xpath>
+        <value><researchViewY>2.70</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_NightLord"]/researchViewX</xpath>
+        <value><researchViewX>11.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_NightLord"]/researchViewY</xpath>
+        <value><researchViewY>1.40</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_Salamander"]/researchViewX</xpath>
+        <value><researchViewX>11.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_Salamander"]/researchViewY</xpath>
+        <value><researchViewY>2.00</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_TotE_CustodesFabrication"]/researchViewX</xpath>
+        <value><researchViewX>8.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_TotE_CustodesFabrication"]/researchViewY</xpath>
+        <value><researchViewY>3.50</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_TotE_CustodesGuard"]/researchViewX</xpath>
+        <value><researchViewX>9.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_TotE_CustodesGuard"]/researchViewY</xpath>
+        <value><researchViewY>3.20</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_TotE_Allarus"]/researchViewX</xpath>
+        <value><researchViewX>10.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_TotE_Allarus"]/researchViewY</xpath>
+        <value><researchViewY>3.20</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_TotE_Castellan"]/researchViewX</xpath>
+        <value><researchViewX>11.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_TotE_Castellan"]/researchViewY</xpath>
+        <value><researchViewY>3.20</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Primarchfabrication"]/researchViewX</xpath>
+        <value><researchViewX>9.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Primarchfabrication"]/researchViewY</xpath>
+        <value><researchViewY>3.90</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_Guilliman"]/researchViewX</xpath>
+        <value><researchViewX>10.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_Guilliman"]/researchViewY</xpath>
+        <value><researchViewY>3.70</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_LionArmor"]/researchViewX</xpath>
+        <value><researchViewX>10.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_SM_LionArmor"]/researchViewY</xpath>
+        <value><researchViewY>4.20</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Rulers_MasterForge"]/researchViewX</xpath>
+        <value><researchViewX>14.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Rulers_MasterForge"]/researchViewY</xpath>
+        <value><researchViewY>4.70</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Rulers_OneTrueArmor"]/researchViewX</xpath>
+        <value><researchViewX>15.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Rulers_OneTrueArmor"]/researchViewY</xpath>
+        <value><researchViewY>4.80</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Rulers_FirstCaptainr"]/researchViewX</xpath>
+        <value><researchViewX>15.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Rulers_FirstCaptainr"]/researchViewY</xpath>
+        <value><researchViewY>4.30</researchViewY></value>
+      </li>
+
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Rulers_EmperorRightHand"]/researchViewX</xpath>
+        <value><researchViewX>15.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_Rulers_EmperorRightHand"]/researchViewY</xpath>
+        <value><researchViewY>5.40</researchViewY></value>
+      </li>
+	  
+      <!-- ==================== End of ALL POSITION CHANGES ==================== -->
+      <!-- Flat MayFail replaces — no FindMod needed                     -->
+      <!-- These will silently skip if the def is not loaded             -->
+
+      <!-- GW_GeneSeeding — unlock and reposition MOVED TO OWN PATCH -->
+      <!--<li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GeneSeeding"]/researchViewX</xpath>
+        <value><researchViewX>0.00</researchViewX></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GeneSeeding"]/researchViewY</xpath>
+        <value><researchViewY>0.10</researchViewY></value>
+      </li>
+      <li Class="PatchOperationRemove" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GeneSeeding"]/requiredResearchBuilding</xpath>
+      </li>
+      <li Class="PatchOperationAdd" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GeneSeeding"]</xpath>
+        <value>
+          <requiredResearchBuilding MayRequire="Ludeon.RimWorld.Biotech">HiTechResearchBench</requiredResearchBuilding>
+          <requiredResearchFacilities MayRequire="Ludeon.RimWorld.Biotech">
+            <li>MultiAnalyzer</li>
+          </requiredResearchFacilities>
+        </value>
+      </li> -->
+
+
+      <!-- ==================== LABEL CHANGES ==================== -->
+
+      <!-- GW_GrimworldMaterials → Imperium Materials -->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_GrimworldMaterials"]/label</xpath>
+        <value><label>Imperium Materials</label></value>
+      </li>
+
+      <!-- GW_BlastDoors → Imperium blast doors -->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_BlastDoors"]/label</xpath>
+        <value><label>Imperium blast doors</label></value>
+      </li>
+      <!-- GW_BlastDoors → replace autodoor prereq with SecurityDoor if Anomaly present -->
+      <li Class="PatchOperationFindMod" MayFail="true">
+        <mods><li>Ludeon.RimWorld.Anomaly</li></mods>
+        <match Class="PatchOperationReplace" MayFail="true">
+          <xpath>Defs/ResearchProjectDef[defName="GW_BlastDoors"]/prerequisites/li[.="Autodoor"]</xpath>
+          <value><li>SecurityDoor</li></value>
+        </match>
+      </li>
+
+      <!-- GW_AM_BasicImperiumDefense — rename + description-->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_BasicImperiumDefense"]/label</xpath>
+        <value><label>Imperial Infrastructure</label></value>
+      </li>
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_BasicImperiumDefense"]/description</xpath>
+        <value><description>Study the fundamental engineering doctrines of the Imperium of Man. From coils of barbed wire to prefabricated strongpoints, the Imperium has spent ten thousand years perfecting the art of turning any ground into a fortress. This knowledge forms the backbone of all Imperial defensive construction.</description></value>
+      </li>
+
+      <!-- GW_AM_ImperiumDefense — description -->
+      <li Class="PatchOperationReplace" MayFail="true">
+        <xpath>Defs/ResearchProjectDef[defName="GW_AM_ImperiumDefense"]/description</xpath>
+        <value><description>Apply the full weight of Imperial military engineering to your defenses. Where lesser armies dig foxholes, the Imperium builds cathedrals of war — towering bastions, interlocking fields of fire, and kill zones consecrated in the blood of those foolish enough to assault them.</description></value>
+      </li>
+
+
+      <!-- Hide AdvancedBolters and PlasmaWeapons when Angels of Death is not present -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>Grimworld 40,000 - Angels of Death</li></mods>
+        <nomatch Class="PatchOperationSequence">
+          <operations>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ResearchProjectDef[defName="GW_AdvancedBolters"]</xpath>
+              <value><requiredResearchBuilding>MPI_ModMissing_AngelsOfDeath</requiredResearchBuilding></value>
+            </li>
+            <li Class="PatchOperationAdd" MayFail="true">
+              <xpath>Defs/ResearchProjectDef[defName="GW_PlasmaWeapons"]</xpath>
+              <value><requiredResearchBuilding>MPI_ModMissing_AngelsOfDeath</requiredResearchBuilding></value>
+            </li>
+          </operations>
+        </nomatch>
+      </li>
+
+    </operations>
+  </Operation>
+
+</Patch>

--- a/1.6/Patches/patchVEHook.xml
+++ b/1.6/Patches/patchVEHook.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ============================================================ -->
+<!-- patchVEHook.xml                                              -->
+<!-- Vanilla Expanded + GW Hook Patch.                            -->
+<!-- Gates GW items behind Vanilla Expanded research when the     -->
+<!-- relevant VE mods are loaded alongside GW mods.               -->
+<!-- Organized by GW mod, with nested FindMod checks for each VE  -->
+<!-- mod. Controlled by the VEHook toggle in MPI settings.        -->
+<!-- ============================================================ -->
+<Patch>
+
+  <Operation Class="GW_Frame.PatchOperation_GWPatch">
+    <patchName>VEHook</patchName>
+    <operations>
+
+      <!-- ==================== Hammer of the Imperium ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Hammer of the Imperium</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- ===== Vanilla Apparel Expanded ===== -->
+            <li Class="PatchOperationFindMod" MayFail="true">
+              <mods><li>Vanilla Apparel Expanded</li></mods>
+              <match Class="PatchOperationSequence">
+                <operations>
+
+                  <!-- Cadian fatigues, fieldcap, officer uniform, gorgets → VAE_MilitaryClothing -->
+                  <!-- <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_Fatigues"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li> -->
+                  <!-- <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_FatiguesGreen"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li> -->
+                  <!-- <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_CadianCommanderFatigues"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li> -->
+                  <!-- <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_Fieldcap"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li> -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_OfficerGorget"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CommissarGorget"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <!-- Cadian jumpsuit → VAE_WorkAttire -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_Cadian_CrewJumpsuit"]</xpath>
+                    <value><researchPrerequisites><li>VAE_WorkAttire</li></researchPrerequisites></value>
+                  </li>
+
+                  <!-- Valhallan officer cap + officer ushanka → VAE_MilitaryClothing -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_AM_Valhallan_OfficerCap"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_AM_Valhallan_OfficerUshanka"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <!-- Cadian officer uniform → VAE_MilitaryClothing -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_CadianCommanderFatigues"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <!-- Tallarn officer headwrap → VAE_MilitaryClothing -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_AM_TDR_OfficerHeadwrap"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+
+                  <!-- Cadian backpacks -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_BattlelineBackpack"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <!-- Kasrkin backpacks -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_MedicalBackpack"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_VoxBackpack"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+
+                </operations>
+              </match>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- ==================== Regiments of Renown ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Regiments of Renown</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- ===== Vanilla Apparel Expanded ===== -->
+            <li Class="PatchOperationFindMod" MayFail="true">
+              <mods><li>Vanilla Apparel Expanded</li></mods>
+              <match Class="PatchOperationSequence">
+                <operations>
+
+                  <!-- Scion beret + fatigues → VAE_MilitaryClothing -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_ROR_TempestusScion_Beret"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_Fatigues"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <!-- Catachan vest → VAE_MilitaryClothing -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_ROR_CatachanOuter"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <!-- Valhallan officer greatcoat → VAE_MilitaryClothing -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Valhallan_OfficerGreatCoat"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <!-- Kasrkin medicae backpack + vox backpack → handled in HoI VAE block -->
+
+                </operations>
+              </match>
+            </li>
+
+            <!-- ===== Vanilla Armour Expanded ===== -->
+            <li Class="PatchOperationFindMod" MayFail="true">
+              <mods><li>Vanilla Armour Expanded</li></mods>
+              <match Class="PatchOperationSequence">
+                <operations>
+
+                  <!-- Tanith ghillie suit → VAE_MlitaryCamouflage (typo is correct, matches mod source) -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_ROR_Tanith1stGhili"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MlitaryCamouflage</li></researchPrerequisites></value>
+                  </li>
+
+                </operations>
+              </match>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+      <!-- GW_AM_OfficersOfAM → require VAE_MilitaryClothing if Vanilla Apparel Expanded present -->
+      <li Class="PatchOperationFindMod" MayFail="true">
+        <mods><li>Vanilla Apparel Expanded</li></mods>
+        <match Class="PatchOperationAdd" MayFail="true">
+          <xpath>Defs/ResearchProjectDef[defName="GW_AM_OfficersOfAM"]/prerequisites</xpath>
+          <value><li>VAE_MilitaryClothing</li></value>
+        </match>
+      </li>
+	  
+      <!-- ==================== Dead Men of Krieg ==================== -->
+      <li Class="PatchOperationFindMod">
+        <mods><li>GrimWorld 40,000 - Dead Men</li></mods>
+        <match Class="PatchOperationSequence">
+          <operations>
+
+            <!-- ===== Vanilla Apparel Expanded ===== -->
+            <li Class="PatchOperationFindMod" MayFail="true">
+              <mods><li>Vanilla Apparel Expanded</li></mods>
+              <match Class="PatchOperationSequence">
+                <operations>
+
+                  <!-- DK officer greatcoat → VAE_MilitaryClothing -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_DM_KriegOfficerUniform"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <!-- DK webbing → VAE_MilitaryClothing -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_DM_KriegBelt"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+                  <!-- DK engineer webbing → VAE_MilitaryClothing -->
+                  <li Class="PatchOperationAdd" MayFail="true">
+                    <xpath>Defs/ThingDef[defName="GW_HOI_DM_KriegEngineerPack"]</xpath>
+                    <value><researchPrerequisites><li>VAE_MilitaryClothing</li></researchPrerequisites></value>
+                  </li>
+
+                </operations>
+              </match>
+            </li>
+
+          </operations>
+        </match>
+      </li>
+
+    </operations>
+  </Operation>
+
+</Patch>

--- a/About/About.xml
+++ b/About/About.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetaData>
 	<name>GrimWorld 40,000 - Core Imperialis</name>
-	<author>Clashgore, Odzmang, BlackMarket420, Tittymcswaggy, Alite, Abomination, Epsilon, Maxim, Shun The Witch, Samael, Con</author>
+	<author>Clashgore, Odzmang, BlackMarket420, Tittymcswaggy, Alite, Abomination, Epsilon, Maxim, Shun The Witch, Samael, Con, atxmatt2510</author>
 	<packageId>Grimworld.Core</packageId>
 	<modIconPath IgnoreIfNoMatchingField="True">UI/CoreImperialisModIcon</modIconPath>
 	<supportedVersions>


### PR DESCRIPTION
Sound Defs — Centralized to Core-Imperialis/1.6/Defs/SoundDefs.xml Moved shared sound defs here since Core-Imperialis is always a dependency: •	GW_Grenade_Gun_Sound — clip folder Weapons/GrenadeLauncher (3 ogg files) •	Smite — clip SmiteSFX
•	ChainSword — clip folder Weapons/ChainSword
•	PowerSword — clip folder Weapons/PowerSword
•	Corpse Starch Fix - MPI integration
•	Odyssey Airtight Fix - MPI integration
•	GW_PatchDefs addition - MPI addition
•	GWCat addition - MPI addition
•	GWResearch addition - MPI addition
•	GWBalance addition - MPI addition
•	GWGene addition - MPI addition
•	VEHook addition - MPI addition

GW4KArmor (ItemPainter Assembly)
Build Fixes — RimWorld 1.6 API Changes
•	Core.cs — added [StaticConstructorOnStartup] attribute; made asset bundle loading version-independent (tries 1.6, 1.5, 1.4 in order); sets GW4KArmor.UI.MaterialPool.StaticMask after bundle loads. •	MaterialPool.cs — added [StaticConstructorOnStartup] attribute and using Verse;; changed StaticMask from inline new Material(Core.MaskMaterial) initializer to a field set by Core after the bundle is loaded (resolves circular static init crash). •	MaskTextureStorage.cs — added using RimWorld; for BodyTypeDefOf; replaced removed ContentFinder<Texture2D>.Exists(path) with ContentFinder<Texture2D>.Get(path, false) == null. •	Command_ActionWithPaintOptions.cs — replaced Comp.Props.maskCount - 1 with Comp.Props.Masks.GetAvailableMaskIndices(...).Count - 1 (field was removed). •	Comp_TriColorMask.cs — fixed CS0649 warnings; _gizmo and _gizmoMulti backing fields now assigned in the else branches of their property getters. Mask Auto-Discovery
•	Removed maskCount field from CompProperties_TriColorMask — masks are now auto-discovered at runtime by sequentially probing for _mask1, _mask2, etc. until a missing file is encountered (MaskTextureStorage.GetAvailableMaskIndices). •	CompProperties_TriColorMask.ConfigErrors() — fixed NullReferenceException; now uses parentDef parameter (available at config-check time) instead of Def property (assigned later via FindMaskableThings). Removed premature Masks access during config phase. •	TexPath getter — null-checked Def and graphicData to prevent crash when called before FindMaskableThings runs.