### PR TITLE
Core-Imperialis — patchGWCat.xml

### DIFF
--- a/1.6/Defs/CoreResearches.xml
+++ b/1.6/Defs/CoreResearches.xml
@@ -62,19 +62,19 @@
         <discoveredLetterText>You now have the technology to build a cogitator. Many advanced technologies of the Imperium of Man require studying STC fragments at a cogitator before research can begin.\n\nYou can begin studying at the cogitator building after obtaining STC fragments from certain traders.</discoveredLetterText>
 	</ResearchProjectDef>
 	
-	<!-- <ResearchProjectDef ParentName="GW_ImperiumTechBase"> -->
-        <!-- <defName>indoctrination_chamber</defName> -->
-        <!-- <label>Indoctrination chamber</label> -->
-        <!-- <description>Construct the Indoctrination Chamber, an Astartes tool to influence subjects into their way of thinking.</description> -->
-        <!-- <prerequisites> -->
-            <!-- <li>MultiAnalyzer</li> -->
-			<!-- <li>Cryptosleep</li> -->
-        <!-- </prerequisites> -->
-		<!-- <techLevel>Spacer</techLevel> -->
-		<!-- <baseCost>4500</baseCost> -->
-		<!-- <researchViewX>3.00</researchViewX> -->
-		<!-- <researchViewY>0.00</researchViewY> -->
-	<!-- </ResearchProjectDef> -->
+	<ResearchProjectDef ParentName="GW_ImperiumTechBase">
+        <defName>indoctrination_chamber</defName>
+        <label>Indoctrination chamber</label>
+        <description>Construct the Indoctrination Chamber, an Astartes tool to influence subjects into their way of thinking.</description>
+        <prerequisites>
+            <li>MultiAnalyzer</li>
+			<li>Cryptosleep</li>
+        </prerequisites>
+		<techLevel>Spacer</techLevel>
+		<baseCost>4500</baseCost>
+		<researchViewX>7.00</researchViewX>
+		<researchViewY>4.00</researchViewY>
+	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="GW_ImperiumTechBase">
 		<defName>GW_GrimworldMaterials</defName>

--- a/1.6/Defs/DesignationCategories.xml
+++ b/1.6/Defs/DesignationCategories.xml
@@ -1,16 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
-    <DesignationCategoryDef>
-        <defName>GrimworldCategory</defName>
-        <label>Grimworld</label>
-        <order>10</order>
-        <specialDesignatorClasses>
-            <li>Designator_Cancel</li>
-            <li>Designator_Deconstruct</li>
-        </specialDesignatorClasses>
-    </DesignationCategoryDef>
-
 <!--
+GrimworldCategory is defined in Grimworld-Framework/1.6/Defs/DesignationCategories.xml
 Add <uiOrder> to all buildings in this category to force a specific order. This goes directly in the ThingDef.
 -->
 </Defs>

--- a/1.6/Defs/IndoctrinationChamber/Chamber_Thing.xml
+++ b/1.6/Defs/IndoctrinationChamber/Chamber_Thing.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+    <ThingDef ParentName="BuildingBase">
+        <defName>IndoctrinationChamber</defName>
+        <label>indoctrination chamber</label>
+        <description>A pod for one person, designed for the Adeptus Astartes. The subject is placed into the pod and information is transmitted into their mind. While it was primarily used as a form of accelerated training, it also served to influence the subject's mind into becoming a model Space Marine. \n\nRimworlders have repurposed this degraded design to brainwash subjects (such as unwaveringly loyal prisoners) into a more pliable state, regardless of past loyalties - though there is a risk of permanent brain damage. \n\nSpace Marines are as much monks as they are warriors. In the Age of the Imperium, complex and arcane rituals are required even for the act of putting on one's Power Armor. But while they were initially completely loyal to the Emperor, they were possessed by a certain arrogance that made them surprisingly vulnerable to being corrupted by Chaos.</description>
+        <thingClass>Chamber.Building_Chamber</thingClass>
+        <containedPawnsSelectable>true</containedPawnsSelectable>
+        <drawerType>MapMeshAndRealTime</drawerType>
+        <graphicData>
+            <texPath>Chamber/IndoctrinationChamber_Base</texPath>
+            <graphicClass>Graphic_Single</graphicClass>
+            <drawSize>(4.5, 4.5)</drawSize>
+        </graphicData>
+        <researchPrerequisites>
+            <li>Cryptosleep</li>
+            <li>indoctrination_chamber</li>
+        </researchPrerequisites>
+        <altitudeLayer>Building</altitudeLayer>
+        <uiIconPath>Chamber/IndoctrinationChamber_UI</uiIconPath>
+        <passability>PassThroughOnly</passability>
+        <pathCost>42</pathCost>
+        <blockWind>true</blockWind>
+        <fillPercent>0.5</fillPercent>
+        <canOverlapZones>false</canOverlapZones>
+        <statBases>
+            <WorkToBuild>3200</WorkToBuild>
+            <MaxHitPoints>250</MaxHitPoints>
+            <Flammability>0.5</Flammability>
+        </statBases>
+        <tickerType>Normal</tickerType>
+        <size>(3,3)</size>
+        <designationCategory>GrimworldCategory</designationCategory>
+        <uiOrder>2050</uiOrder>
+        <hasInteractionCell>true</hasInteractionCell>
+        <interactionCellOffset>(0,0,-2)</interactionCellOffset>
+        <rotatable>false</rotatable>
+        <defaultPlacingRot>North</defaultPlacingRot>
+        <building>
+            <ai_chillDestination>false</ai_chillDestination>
+            <destroySound>BuildingDestroyed_Metal_Small</destroySound>
+            <isPlayerEjectable>true</isPlayerEjectable>
+        </building>
+        <costList>
+            <Steel>350</Steel>
+            <Plasteel>40</Plasteel>
+            <HP_Ceramite>30</HP_Ceramite>
+            <ComponentIndustrial>20</ComponentIndustrial>
+            <ComponentSpacer>3</ComponentSpacer>
+        </costList>
+        <placeWorkers>
+            <li>PlaceWorker_PreventInteractionSpotOverlap</li>
+        </placeWorkers>
+        <inspectorTabs>
+            <li>ITab_ContentsCasket</li>
+        </inspectorTabs>
+        <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+        <constructionSkillPrerequisite>8</constructionSkillPrerequisite>
+        <modExtensions>
+            <li Class="Chamber.ChamberModExtension">
+                <ticksToFinish>480</ticksToFinish>
+                <brainDamageChance>0.9</brainDamageChance>
+                <brainDamageSeverity>0.2</brainDamageSeverity>
+                <chamberTopGraphic>
+                    <texPath>Chamber/IndoctrinationChamber_Top</texPath>
+                    <graphicClass>Graphic_Single</graphicClass>
+                    <drawSize>(4.5,4.5)</drawSize>
+                    <shaderType>Cutout</shaderType>
+                </chamberTopGraphic>
+            </li>
+        </modExtensions>
+    </ThingDef>
+</Defs>

--- a/1.6/Patches/patchGWCat.xml
+++ b/1.6/Patches/patchGWCat.xml
@@ -112,6 +112,12 @@
               <value><designationCategory>Misc</designationCategory></value>
             </li>
 
+            <!-- Indoctrination Chamber → Misc (same category as cryptosleep caskets) -->
+            <li Class="PatchOperationReplace" MayFail="true">
+              <xpath>Defs/ThingDef[defName="IndoctrinationChamber"]/designationCategory</xpath>
+              <value><designationCategory>Misc</designationCategory></value>
+            </li>
+
             <!-- Remove GrimworldCategory -->
             <li Class="PatchOperationRemove" MayFail="true">
               <xpath>Defs/DesignationCategoryDef[defName="GrimworldCategory"]</xpath>

--- a/About/About.xml
+++ b/About/About.xml
@@ -37,6 +37,12 @@
 		</v1.5>
 		<v1.6>
 			<li>
+				<packageId>Grimworld.Framework</packageId>
+				<displayName>GrimWorld 40,000 - Framework</displayName>
+				<steamWorkshopUrl>https://steamcommunity.com/workshop/filedetails/?id=3119805903</steamWorkshopUrl>
+				<downloadUrl>https://github.com/GrimWorld-40-000/GrimWorld-Framework</downloadUrl>
+			</li>
+			<li>
 				<packageId>OskarPotocki.VanillaFactionsExpanded.Core</packageId>
 				<displayName>Vanilla Expanded Framework</displayName>
 				<steamWorkshopUrl>https://steamcommunity.com/workshop/filedetails/?id=2023507013</steamWorkshopUrl>


### PR DESCRIPTION
Added IndoctrinationChamber → Misc remap before GrimworldCategory is removed, fixing the cross-reference error that caused IndoctrinationChamber to lose its designation category Core-Imperialis — Chamber_Thing.xml
Changed building size from (3,4) to (3,3)
Core-Imperialis — CoreResearches.xml
Reinstated Indoctrination_chamber research node
Moved indoctrination_chamber research node to position (7.00, 4.00)