### PR TITLE
Core-Imperialis — Corpse Starch bulk recipe rebalance

### DIFF
--- a/1.6/Defs/ThingDefs/ThingDefsCorpseStarch.xml
+++ b/1.6/Defs/ThingDefs/ThingDefsCorpseStarch.xml
@@ -27,7 +27,7 @@
         <li>ElectricStove</li>
 		<li>FueledStove</li>
       </recipeUsers>
-      <bulkRecipeCount>60</bulkRecipeCount>
+      <bulkRecipeCount>4</bulkRecipeCount>
 	  <workSkill>Cooking</workSkill>
     </recipeMaker>
       


### PR DESCRIPTION
ThingDefsCorpseStarch.xml: Reduced bulkRecipeCount from 60 to 4.

Bulk recipe now produces 4× the standard yield (4 units, 20 human meat, 2800 work) instead of the previous 60-unit batch (300 meat, 42000 work).

Suggested 10x recipe: 10 meals = 50 meat 7000 ticks