### PR TITLE
Matt update

### DIFF
--- a/1.6/Defs/ThingDefs/ThingDefsCorpseStarch.xml
+++ b/1.6/Defs/ThingDefs/ThingDefsCorpseStarch.xml
@@ -27,7 +27,7 @@
         <li>ElectricStove</li>
 		<li>FueledStove</li>
       </recipeUsers>
-      <bulkRecipeCount>60</bulkRecipeCount>
+      <bulkRecipeCount>4</bulkRecipeCount>
 	  <workSkill>Cooking</workSkill>
     </recipeMaker>
       

--- a/1.6/Mods/Vehicles/Defs/VoGResearches.xml
+++ b/1.6/Mods/Vehicles/Defs/VoGResearches.xml
@@ -177,7 +177,7 @@
 			<li>GW_ImperialLandMilitaryLightVehicleResearch</li>
 		</prerequisites>
 		<researchViewY>0.00</researchViewY>
-	</ResearchProjectDef>0
+	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="GW_Tier4LandMilitaryVehicleResearch">
 		<defName>GW_ImperialLandMilitaryHeavyVehicleResearch</defName>


### PR DESCRIPTION
VogResearches.xml
- stray 0 removed that caused the entire VoGResearches.xml to fail parsing, silently dropping all vehicle research defs.