### PR TITLE
Furnace

### DIFF
--- a/1.6/Defs/ThingDefs/ThingDefsCorpseStarch.xml
+++ b/1.6/Defs/ThingDefs/ThingDefsCorpseStarch.xml
@@ -27,7 +27,7 @@
         <li>ElectricStove</li>
 		<li>FueledStove</li>
       </recipeUsers>
-      <bulkRecipeCount>60</bulkRecipeCount>
+      <bulkRecipeCount>4</bulkRecipeCount>
 	  <workSkill>Cooking</workSkill>
     </recipeMaker>
       

--- a/1.6/Defs/ThingDefs/ThingDefs_Resource_Manufactured.xml
+++ b/1.6/Defs/ThingDefs/ThingDefs_Resource_Manufactured.xml
@@ -387,4 +387,72 @@
             <HP_Ceramite>20</HP_Ceramite>
         </products>
     </RecipeDef>
+
+    <RecipeDef>
+        <defName>GW_ExtractMetalFromSlag</defName>
+        <label>smelt metal from slag</label>
+        <description>Use the furnace's intense heat to extract useful metal from slag chunks.</description>
+        <jobString>Smelting metal from slag.</jobString>
+        <workAmount>348</workAmount>
+        <workSpeedStat>SmeltingSpeed</workSpeedStat>
+        <effectWorking>Smelt</effectWorking>
+        <soundWorking>Recipe_Smelt</soundWorking>
+        <ingredients>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>ChunkSlagSteel</li>
+                        <li>ChunkMechanoidSlag</li>
+                    </thingDefs>
+                </filter>
+                <count>1</count>
+            </li>
+        </ingredients>
+        <products>
+            <Steel>15</Steel>
+        </products>
+        <fixedIngredientFilter>
+            <thingDefs>
+                <li>ChunkSlagSteel</li>
+                <li>ChunkMechanoidSlag</li>
+            </thingDefs>
+        </fixedIngredientFilter>
+        <recipeUsers>
+            <li>GW_Furnace</li>
+        </recipeUsers>
+    </RecipeDef>
+
+    <RecipeDef>
+        <defName>GW_ExtractMetalFromSlagBulk</defName>
+        <label>smelt metal from slag x3</label>
+        <description>Use the furnace's intense heat to extract useful metal from several slag chunks at once.</description>
+        <jobString>Smelting metal from slag x3.</jobString>
+        <workAmount>1044</workAmount>
+        <workSpeedStat>SmeltingSpeed</workSpeedStat>
+        <effectWorking>Smelt</effectWorking>
+        <soundWorking>Recipe_Smelt</soundWorking>
+        <ingredients>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>ChunkSlagSteel</li>
+                        <li>ChunkMechanoidSlag</li>
+                    </thingDefs>
+                </filter>
+                <count>3</count>
+            </li>
+        </ingredients>
+        <products>
+            <Steel>60</Steel>
+        </products>
+        <fixedIngredientFilter>
+            <thingDefs>
+                <li>ChunkSlagSteel</li>
+                <li>ChunkMechanoidSlag</li>
+            </thingDefs>
+        </fixedIngredientFilter>
+        <recipeUsers>
+            <li>GW_Furnace</li>
+        </recipeUsers>
+    </RecipeDef>
 </Defs>


### PR DESCRIPTION
Pull request

Patch Notes:
- Added two GrimWorld furnace-only smelting recipes:
GW_ExtractMetalFromSlag
  - 1 slag chunk -> 15 steel
  - workAmount: 348
  - About 15% faster than vanilla electric smelter’s 400
GW_ExtractMetalFromSlagBulk
  - 3 slag chunks -> 60 steel
  - workAmount: 1044
  - About 15% faster than doing three vanilla smelts (1200 / 1.15)
- Both accept:
  - ChunkSlagSteel
  - ChunkMechanoidSlag
- Both are scoped only to:
  - GW_Furnace